### PR TITLE
Fix crash in property panel when doing undo/redo

### DIFF
--- a/Source/Mythica/Private/MythicaTypes.h
+++ b/Source/Mythica/Private/MythicaTypes.h
@@ -40,44 +40,100 @@ struct FMythicaInputs
     TArray<FMythicaInput> Inputs;
 };
 
+UENUM()
+enum class EMythicaParameterType : uint8
+{
+    Int,
+    Float,
+    Bool,
+    String
+};
+
+USTRUCT()
 struct FMythicaParameterInt
 {
+    GENERATED_BODY()
+
+    UPROPERTY()
     TArray<int> Values;
+
+    UPROPERTY()
     TArray<int> DefaultValues;
+
+    UPROPERTY()
     TOptional<int> MinValue;
+
+    UPROPERTY()
     TOptional<int> MaxValue;
 };
 
+USTRUCT()
 struct FMythicaParameterFloat
 {
+    GENERATED_BODY()
+
+    UPROPERTY()
     TArray<float> Values;
+
+    UPROPERTY()
     TArray<float> DefaultValues;
+
+    UPROPERTY()
     TOptional<float> MinValue;
+
+    UPROPERTY()
     TOptional<float> MaxValue;
 };
 
+USTRUCT()
 struct FMythicaParameterBool
 {
+    GENERATED_BODY()
+
+    UPROPERTY()
     bool Value = false;
+
+    UPROPERTY()
     bool DefaultValue = false;
 };
 
+USTRUCT()
 struct FMythicaParameterString
 {
+    GENERATED_BODY()
+
+    UPROPERTY()
     FString Value;
+
+    UPROPERTY()
     FString DefaultValue;
 };
-
-using FMythicaParameterValue = TVariant<FMythicaParameterInt, FMythicaParameterFloat, FMythicaParameterBool, FMythicaParameterString>;
 
 USTRUCT(BlueprintType)
 struct FMythicaParameter
 {
     GENERATED_BODY()
 
+    UPROPERTY()
     FString Name;
+
+    UPROPERTY()
     FString Label;
-    FMythicaParameterValue Value;
+
+    UPROPERTY()
+    EMythicaParameterType Type = EMythicaParameterType::Int;
+
+    UPROPERTY()
+    FMythicaParameterInt ValueInt;
+
+    UPROPERTY()
+    FMythicaParameterFloat ValueFloat;
+
+    UPROPERTY()
+    FMythicaParameterBool ValueBool;
+
+    UPROPERTY()
+    FMythicaParameterString ValueString;
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
The undo/redo system relies on the serialization system generated by UPROPERTY() fields. When you hit undo it will recreate the FMythicaParameters object using the old serialized data. However since many of the fields weren't tagged as UPROPERTY() before, it would just cause most of the fields to be cleared. This was causing indexing into the Values array to crash since the array got cleared.

Unfortunately TVariant isn't supported with UPROPERTY(). This PR changes the data structure to a different format that is more compatible with UPROPERTY() tagging.

There is a bit more boilerplate to add to ensure the data supports undo/redo. But for now this change avoids the crash and makes it compatible with undo/redo once we get to setting that up.