### PR TITLE
Add option to automatically regenerage mesh when parameters change

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -22,6 +22,7 @@ void UMythicaComponent::RegenerateMesh()
 {
     if (RequestId > 0)
     {
+        QueueRegenerate = true;
         return;
     }
 
@@ -102,6 +103,12 @@ void UMythicaComponent::OnJobStateChanged(int InRequestId, EMythicaJobState InSt
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
     MythicaEditorSubsystem->OnJobStateChange.RemoveDynamic(this, &UMythicaComponent::OnJobStateChanged);
     RequestId = -1;
+
+    if (QueueRegenerate)
+    {
+        QueueRegenerate = false;
+        RegenerateMesh();
+    }
 }
 
 void UMythicaComponent::UpdateMesh()

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -47,7 +47,13 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
     {
         if (RegenerateOnParameterChange)
         {
-            RegenerateMesh();
+            if (PropertyChangedEvent.ChangeType == EPropertyChangeType::Interactive)
+            {
+                GEditor->GetTimerManager()->SetTimer(DelayRegenerateHandle, [this]() { RegenerateMesh(); }, 0.05f, false); }
+            else
+            {
+                RegenerateMesh();
+            }
         }
     }
 }

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -45,7 +45,10 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
     }
     else if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, Parameters))
     {
-        RegenerateMesh();
+        if (RegenerateOnParameterChange)
+        {
+            RegenerateMesh();
+        }
     }
 }
 

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -42,6 +42,10 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
     {
         OnJobDefIdChanged();
     }
+    else if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, Parameters))
+    {
+        RegenerateMesh();
+    }
 }
 
 static void ForceRefreshDetailsViewPanel()

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -49,7 +49,8 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
         {
             if (PropertyChangedEvent.ChangeType == EPropertyChangeType::Interactive)
             {
-                GEditor->GetTimerManager()->SetTimer(DelayRegenerateHandle, [this]() { RegenerateMesh(); }, 0.05f, false); }
+                GEditor->GetTimerManager()->SetTimer(DelayRegenerateHandle, [this]() { RegenerateMesh(); }, 0.05f, false); 
+            }
             else
             {
                 RegenerateMesh();

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -49,6 +49,7 @@ private:
     int RequestId = -1;
     EMythicaJobState State = EMythicaJobState::Invalid;
     bool QueueRegenerate = false;
+    FTimerHandle DelayRegenerateHandle;
 
     UPROPERTY()
     TArray<FName> MeshComponentNames;

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -33,6 +33,9 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
     FMythicaJobDefinitionId JobDefId;
 
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
+    bool RegenerateOnParameterChange = true;
+
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters")
     FMythicaParameters Parameters;
 

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -45,6 +45,7 @@ public:
 private:
     int RequestId = -1;
     EMythicaJobState State = EMythicaJobState::Invalid;
+    bool QueueRegenerate = false;
 
     UPROPERTY()
     TArray<FName> MeshComponentNames;

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -1185,7 +1185,7 @@ void UMythicaEditorSubsystem::OnMeshDownloadResponse(FHttpRequestPtr Request, FH
     GIsSilent = true;
     UEditorLoadingAndSavingUtils::SavePackages(Packages, true);
     FTimerHandle DummyHandle;
-    GEditor->GetTimerManager()->SetTimer(DummyHandle, [=]() { GIsSilent = PrevSilent; }, 0.1f, true); // Delay until after asset validation
+    GEditor->GetTimerManager()->SetTimer(DummyHandle, [=]() { GIsSilent = PrevSilent; }, 0.1f, false); // Delay until after asset validation
 
     RequestData->ImportDirectory = CreatedImportDirectory;
     SetJobState(RequestId, EMythicaJobState::Completed);

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -74,7 +74,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     {
                         FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                         if (Parameters)
+                        {
                             Parameters->Parameters[ParamIndex].ValueFloat.Values[ComponentIndex] = NewValue;
+                            HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
+                        }
                     };
 
                     HorizontalBox->AddSlot()
@@ -111,7 +114,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     {
                         FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                         if (Parameters)
+                        {
                             Parameters->Parameters[ParamIndex].ValueInt.Values[ComponentIndex] = NewValue;
+                            HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
+                        }
                     };
 
                     HorizontalBox->AddSlot()
@@ -148,7 +154,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
+                    {
                         Parameters->Parameters[ParamIndex].ValueBool.Value = (NewState == ECheckBoxState::Checked);
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
+                    }
                 };
 
                 ValueWidget = SNew(SCheckBox)
@@ -168,7 +177,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
+                    {
                         Parameters->Parameters[ParamIndex].ValueString.Value = InText.ToString();
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
+                    }
                 };
 
                 ValueWidget = SNew(SMultiLineEditableText)

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -48,7 +48,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
         return;
     }
 
-    TWeakPtr<IPropertyHandle> HandleWeak = StructPropertyHandle.ToWeakPtr();
+    HandleWeak = StructPropertyHandle.ToWeakPtr();
     for (int32 ParamIndex = 0; ParamIndex < Parameters->Parameters.Num(); ++ParamIndex)
     {
         const FMythicaParameter& Parameter = Parameters->Parameters[ParamIndex];
@@ -64,20 +64,30 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 for (int ComponentIndex = 0; ComponentIndex < Parameter.ValueFloat.Values.Num(); ++ComponentIndex)
                 {
-                    auto Value = [=]()
+                    auto Value = [this, ParamIndex, ComponentIndex]()
                     {
                         FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                         return Parameters ? Parameters->Parameters[ParamIndex].ValueFloat.Values[ComponentIndex] : 0.0f;
                     };
 
-                    auto OnValueChanged = [=](float NewValue)
+                    auto OnValueChanged = [this, ParamIndex, ComponentIndex](float NewValue)
                     {
                         FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                         if (Parameters)
                         {
                             Parameters->Parameters[ParamIndex].ValueFloat.Values[ComponentIndex] = NewValue;
-                            HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
+                            HandleWeak.Pin()->NotifyPostChange(UsingSlider ? EPropertyChangeType::Interactive : EPropertyChangeType::ValueSet);
                         }
+                    };
+
+                    auto OnBeginSliderMovement = [this]() 
+                    {
+                        UsingSlider = true;
+                    };
+
+                    auto OnEndSliderMovement = [this](float NewValue)
+                    {
+                        UsingSlider = false;
                     };
 
                     HorizontalBox->AddSlot()
@@ -86,6 +96,8 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                             SNew(SNumericEntryBox<float>)
                                 .Value_Lambda(Value)
                                 .OnValueChanged_Lambda(OnValueChanged)
+                                .OnBeginSliderMovement_Lambda(OnBeginSliderMovement)
+                                .OnEndSliderMovement_Lambda(OnEndSliderMovement)
                                 .AllowSpin(true)
                                 .MinValue(Parameter.ValueFloat.MinValue)
                                 .MaxValue(Parameter.ValueFloat.MaxValue)
@@ -104,20 +116,30 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 for (int ComponentIndex = 0; ComponentIndex < Parameter.ValueInt.Values.Num(); ++ComponentIndex)
                 {
-                    auto Value = [=]()
+                    auto Value = [this, ParamIndex, ComponentIndex]()
                     {
                         FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                         return Parameters ? Parameters->Parameters[ParamIndex].ValueInt.Values[ComponentIndex] : 0;
                     };
 
-                    auto OnValueChanged = [=](int NewValue)
+                    auto OnValueChanged = [this, ParamIndex, ComponentIndex](int NewValue)
                     {
                         FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                         if (Parameters)
                         {
                             Parameters->Parameters[ParamIndex].ValueInt.Values[ComponentIndex] = NewValue;
-                            HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
+                            HandleWeak.Pin()->NotifyPostChange(UsingSlider ? EPropertyChangeType::Interactive : EPropertyChangeType::ValueSet);
                         }
+                    };
+
+                    auto OnBeginSliderMovement = [this]()
+                    {
+                        UsingSlider = true;
+                    };
+
+                    auto OnEndSliderMovement = [this](int NewValue)
+                    {
+                        UsingSlider = false;
                     };
 
                     HorizontalBox->AddSlot()
@@ -126,6 +148,8 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                             SNew(SNumericEntryBox<int>)
                                 .Value_Lambda(Value)
                                 .OnValueChanged_Lambda(OnValueChanged)
+                                .OnBeginSliderMovement_Lambda(OnBeginSliderMovement)
+                                .OnEndSliderMovement_Lambda(OnEndSliderMovement)
                                 .AllowSpin(true)
                                 .MinValue(Parameter.ValueInt.MinValue)
                                 .MaxValue(Parameter.ValueInt.MaxValue)
@@ -140,14 +164,14 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
             }
             case EMythicaParameterType::Bool:
             {
-                auto IsChecked = [=]()
+                auto IsChecked = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     bool Value = Parameters ? Parameters->Parameters[ParamIndex].ValueBool.Value : false;
                     return Value ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
                 };
 
-                auto OnCheckStateChanged = [=](ECheckBoxState NewState)
+                auto OnCheckStateChanged = [this, ParamIndex](ECheckBoxState NewState)
                 {
                     if (NewState == ECheckBoxState::Undetermined)
                         return;
@@ -167,13 +191,13 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
             }
             case EMythicaParameterType::String:
             {
-                auto Text = [=]()
+                auto Text = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     return Parameters ? FText::FromString(Parameters->Parameters[ParamIndex].ValueString.Value) : FText();
                 };
 
-                auto OnTextCommitted = [=](const FText& InText, ETextCommit::Type InCommitType)
+                auto OnTextCommitted = [this, ParamIndex](const FText& InText, ETextCommit::Type InCommitType)
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)

--- a/Source/Mythica/Private/MythicaParametersDetails.h
+++ b/Source/Mythica/Private/MythicaParametersDetails.h
@@ -9,4 +9,9 @@ public:
 
 	virtual void CustomizeHeader(TSharedRef<class IPropertyHandle> StructPropertyHandle, class FDetailWidgetRow& HeaderRow, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
 	virtual void CustomizeChildren(TSharedRef<class IPropertyHandle> StructPropertyHandle, class IDetailChildrenBuilder& StructBuilder, IPropertyTypeCustomizationUtils& StructCustomizationUtils) override;
+
+private:
+	TWeakPtr<IPropertyHandle> HandleWeak;
+
+	bool UsingSlider = false;
 };


### PR DESCRIPTION
The DelayRegenerateHandle is intended to make moving sliders feel less janky. 

In the common case of moving the slider, it would immediate regenerate the mesh with the slider value moved only 1 tick over, and then regenerate the mesh again with the final slider value you moved it to. With this timer it waits until you stop moving the slider before kicking off the regenerate. This is also nice to avoid wasted compute time on the server side.