### PR TITLE
Fix crash on changing levels

### DIFF
--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -171,6 +171,8 @@ class UMythicaEditorSubsystem : public UEditorSubsystem
 	virtual void Initialize(FSubsystemCollectionBase& Collection);
 	virtual void Deinitialize();
 
+	void OnMapChanged(UWorld* InWorld, EMapChangeType InMapChangeType);
+
 public:
 	// Getters
 	UFUNCTION(BlueprintPure, Category = "Mythica")
@@ -265,6 +267,7 @@ private:
 	int CreateJob(const FString& JobDefId, const FMythicaInputs& Inputs, const FMythicaParameters& Params, const FMythicaMaterialParameters& MaterialParams, const FString& ImportName);
 	void SetJobState(int RequestId, EMythicaJobState State);
 	void PollJobStatus();
+	void ClearJobs();
 
 	void SetSessionState(EMythicaSessionState NewState);
 


### PR DESCRIPTION
The UMythicaEditorSubsystem::Jobs::Inputs::Inputs::Actors field may contain hard references to actors in the scene. When the level is unloaded this will cause the object reference system to assert that there are dangling references.

Fixed by clearing out this map on level change. This will also have the effect of cancelling any jobs that were still in flight.

Another option here could have been to change the field to be a weak object reference.