### PR TITLE
Clean up usage of temp files

### DIFF
--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -17,6 +17,8 @@
 #include "ObjectTools.h"
 #include "UObject/SavePackage.h"
 
+#define MYTHICA_CLEAN_TEMP_FILES 1
+
 DEFINE_LOG_CATEGORY(LogMythica);
 
 const TCHAR* ConfigFile = TEXT("PackageInfo.ini");
@@ -673,15 +675,15 @@ void UMythicaEditorSubsystem::OnJobDefinitionsResponse(FHttpRequestPtr Request, 
     OnJobDefinitionListUpdated.Broadcast();
 }
 
-bool UMythicaEditorSubsystem::PrepareInputFiles(const FMythicaInputs& Inputs, TMap<int, FString>& InputFiles)
+bool UMythicaEditorSubsystem::PrepareInputFiles(const FMythicaInputs& Inputs, TMap<int, FString>& InputFiles, FString& ExportDirectory)
 {
-    FString ExportFolder = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), TEXT("ExportCache"));
+    ExportDirectory = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), TEXT("ExportCache"));
     for (int i = 0; i < Inputs.Inputs.Num(); i++)
     {
         const FMythicaInput& Input = Inputs.Inputs[i];
         if (Input.Type == EMythicaInputType::Mesh && Input.Mesh != nullptr)
         {
-            FString FilePath = FPaths::Combine(ExportFolder, FString::Format(TEXT("InputMesh{0}.usdz"), { i }));
+            FString FilePath = FPaths::Combine(ExportDirectory, FString::Format(TEXT("InputMesh{0}.usdz"), { i }));
             bool Success = Mythica::ExportMesh(Input.Mesh, FilePath);
             if (!Success)
             {
@@ -693,7 +695,7 @@ bool UMythicaEditorSubsystem::PrepareInputFiles(const FMythicaInputs& Inputs, TM
         }
         else if (Input.Type == EMythicaInputType::World && !Input.Actors.IsEmpty())
         {
-            FString FilePath = FPaths::Combine(ExportFolder, FString::Format(TEXT("InputMesh{0}.usdz"), { i }));
+            FString FilePath = FPaths::Combine(ExportDirectory, FString::Format(TEXT("InputMesh{0}.usdz"), { i }));
             bool Success = Mythica::ExportActors(Input.Actors, FilePath);
             if (!Success)
             {
@@ -705,7 +707,7 @@ bool UMythicaEditorSubsystem::PrepareInputFiles(const FMythicaInputs& Inputs, TM
         }
         else if (Input.Type == EMythicaInputType::Spline && Input.SplineActor != nullptr)
         {
-            FString FilePath = FPaths::Combine(ExportFolder, FString::Format(TEXT("InputMesh{0}.usdz"), { i }));
+            FString FilePath = FPaths::Combine(ExportDirectory, FString::Format(TEXT("InputMesh{0}.usdz"), { i }));
             bool Success = Mythica::ExportSpline(Input.SplineActor, FilePath);
             if (!Success)
             {
@@ -825,8 +827,9 @@ int UMythicaEditorSubsystem::ExecuteJob(const FString& JobDefId, const FMythicaI
         return -1;
     }
 
+    FString ExportDirectory;
     TMap<int, FString> InputFiles;
-    bool Success = PrepareInputFiles(Inputs, InputFiles);
+    bool Success = PrepareInputFiles(Inputs, InputFiles, ExportDirectory);
     if (!Success)
     {
         UE_LOG(LogMythica, Error, TEXT("Failed to prepare job input files"));
@@ -844,6 +847,10 @@ int UMythicaEditorSubsystem::ExecuteJob(const FString& JobDefId, const FMythicaI
     else
     {
         UploadInputFiles(RequestId, InputFiles);
+        if (MYTHICA_CLEAN_TEMP_FILES)
+        {
+            IFileManager::Get().DeleteDirectory(*ExportDirectory, false, true);
+        }
     }
 
     return RequestId;
@@ -1212,6 +1219,11 @@ void UMythicaEditorSubsystem::OnMeshDownloadResponse(FHttpRequestPtr Request, FH
 
     RequestData->ImportDirectory = CreatedImportDirectory;
     SetJobState(RequestId, EMythicaJobState::Completed);
+
+    if (MYTHICA_CLEAN_TEMP_FILES)
+    {
+        IFileManager::Get().Delete(*FilePath);
+    }
 }
 
 void UMythicaEditorSubsystem::SetSessionState(EMythicaSessionState NewState)

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -473,7 +473,7 @@ void UMythicaEditorSubsystem::OnDownloadAssetResponse(FHttpRequestPtr Request, F
     }
 
     // Save package to disk
-    FString PackagePath = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), PackageId, PackageId + ".zip");
+    FString PackagePath = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), TEXT("PackageCache"), PackageId, PackageId + ".zip");
 
     TArray<uint8> PackageData = Response->GetContent();
     bool PackageWritten = FFileHelper::SaveArrayToFile(PackageData, *PackagePath);
@@ -512,7 +512,7 @@ void UMythicaEditorSubsystem::OnDownloadAssetResponse(FHttpRequestPtr Request, F
             continue;
         }
 
-        FString FilePath = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), PackageId, File);
+        FString FilePath = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), TEXT("PackageCache"), PackageId, File);
         bool FileWritten = FFileHelper::SaveArrayToFile(FileData, *FilePath);
         if (!FileWritten)
         {

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -254,7 +254,7 @@ private:
 
     void OnJobDefinitionsResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
 
-    bool PrepareInputFiles(const FMythicaInputs& Inputs, TMap<int, FString>& InputFiles);
+    bool PrepareInputFiles(const FMythicaInputs& Inputs, TMap<int, FString>& InputFiles, FString& ExportDirectory);
     void UploadInputFiles(int RequestId, const TMap<int, FString>& InputFiles);
     void OnUploadInputFilesResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId, const TMap<int, FString>& InputFiles);
     void SendJobRequest(int RequestId, const TArray<FString>& InputFileIds);

--- a/Source/Mythica/Private/MythicaUSDUtil.cpp
+++ b/Source/Mythica/Private/MythicaUSDUtil.cpp
@@ -31,25 +31,10 @@ static bool ConvertUSDtoUSDZ(const FString& InFile, const FString& OutFile)
     return true;
 }
 
-FString Mythica::MakeUniquePath(const FString& AbsolutePath)
-{
-    FString UniquePath = AbsolutePath;
-
-    uint32 Counter = 1;
-    while (IFileManager::Get().DirectoryExists(*UniquePath))
-    {
-        UniquePath = FString::Printf(TEXT("%s_%d"), *AbsolutePath, Counter);
-        Counter++;
-    }
-
-    return UniquePath;
-}
-
 bool Mythica::ExportMesh(UStaticMesh* Mesh, const FString& ExportPath)
 {
     FString TempFolder = FPaths::Combine(FPaths::GetPath(ExportPath), "USDExport");
-    FString UniqueTempFolder = MakeUniquePath(TempFolder);
-    FString USDPath = FPaths::Combine(UniqueTempFolder, "Export.usd");
+    FString USDPath = FPaths::Combine(TempFolder, "Export.usd");
 
     UStaticMeshExporterUSDOptions* StaticMeshOptions = NewObject<UStaticMeshExporterUSDOptions>();
     StaticMeshOptions->StageOptions.MetersPerUnit = 1.0f;
@@ -79,8 +64,7 @@ bool Mythica::ExportMesh(UStaticMesh* Mesh, const FString& ExportPath)
 bool Mythica::ExportActors(const TArray<AActor*> Actors, const FString& ExportPath)
 {
     FString TempFolder = FPaths::Combine(FPaths::GetPath(ExportPath), "USDExport");
-    FString UniqueTempFolder = MakeUniquePath(TempFolder);
-    FString USDPath = FPaths::Combine(UniqueTempFolder, "Export.usd");
+    FString USDPath = FPaths::Combine(TempFolder, "Export.usd");
 
     // Save original selection
     TArray<AActor*> OriginalSelection;
@@ -136,8 +120,7 @@ bool Mythica::ExportActors(const TArray<AActor*> Actors, const FString& ExportPa
 bool Mythica::ExportSpline(AActor* SplineActor, const FString& ExportPath)
 {
     FString TempFolder = FPaths::Combine(FPaths::GetPath(ExportPath), "USDExport");
-    FString UniqueTempFolder = MakeUniquePath(TempFolder);
-    FString USDPath = FPaths::Combine(UniqueTempFolder, "Export.usd");
+    FString USDPath = FPaths::Combine(TempFolder, "Export.usd");
 
     USplineComponent* SplineComponent = SplineActor->FindComponentByClass<USplineComponent>();
     if (!SplineComponent)

--- a/Source/Mythica/Private/MythicaUSDUtil.h
+++ b/Source/Mythica/Private/MythicaUSDUtil.h
@@ -2,8 +2,6 @@
 
 namespace Mythica
 {
-    FString MakeUniquePath(const FString& AbsolutePath);
-    
     bool ExportMesh(UStaticMesh* Mesh, const FString& ExportPath);
     bool ExportActors(const TArray<AActor*> Actors, const FString& ExportPath);
     bool ExportSpline(AActor* SplineActor, const FString& ExportPath);


### PR DESCRIPTION
Testing the tools for the last week on a simple test case had already accumulated almost a GB of leaked temp files. Changing these to be cleaned up by default.

Left a MYTHICA_CLEAN_TEMP_FILES option for debugging purposes. Also did a bit of clean up for how the temp files are organized for when this debug mode is turned on.