### PR TITLE
Explicitly configure USD import settings

### DIFF
--- a/Source/Mythica/Mythica.Build.cs
+++ b/Source/Mythica/Mythica.Build.cs
@@ -57,7 +57,9 @@ public class Mythica : ModuleRules
                 "UMGEditor",
                 "UnrealEd",
                 "UnrealUSDWrapper",
+                "USDClasses",
                 "USDExporter",
+                "USDStageImporter",
                 "USDUtilities"
                 // ... add private dependencies that you statically link with here ...    
             }

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -1199,14 +1199,8 @@ void UMythicaEditorSubsystem::OnMeshDownloadResponse(FHttpRequestPtr Request, FH
     }
 
     // Import the mesh
-    UAutomatedAssetImportData* ImportData = NewObject<UAutomatedAssetImportData>();
-    ImportData->bReplaceExisting = true;
-    ImportData->DestinationPath = ImportDirectory;
-    ImportData->Filenames = { FilePath };
-
-    FAssetToolsModule& AssetToolsModule = FModuleManager::GetModuleChecked<FAssetToolsModule>("AssetTools");
-    TArray<UObject*> Objects = AssetToolsModule.Get().ImportAssetsAutomated(ImportData);
-    if (Objects.Num() != 1)
+    bool Success = Mythica::ImportMesh(FilePath, ImportDirectory);
+    if (!Success)
     {
         UE_LOG(LogMythica, Error, TEXT("Failed to import generated mesh"));
         SetJobState(RequestId, EMythicaJobState::Failed);

--- a/Source/Mythica/Private/MythicaUSDUtil.cpp
+++ b/Source/Mythica/Private/MythicaUSDUtil.cpp
@@ -202,6 +202,7 @@ bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory
 {
     // Setup import options
     UUsdStageImportOptions* ImportOptions = NewObject<UUsdStageImportOptions>();
+    FGCObjectScopeGuard OptionsGuard(ImportOptions);
 
     ImportOptions->bImportActors = false;
     ImportOptions->bImportGeometry = true;
@@ -244,6 +245,8 @@ bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory
 
     // Import mesh
     UAssetImportTask* Task = NewObject<UAssetImportTask>();
+    FGCObjectScopeGuard TaskGuard(Task);
+
     Task->bAutomated = true;
     Task->bReplaceExisting = true;
     Task->DestinationPath = ImportDirectory;

--- a/Source/Mythica/Private/MythicaUSDUtil.cpp
+++ b/Source/Mythica/Private/MythicaUSDUtil.cpp
@@ -2,6 +2,8 @@
 
 #include "MythicaUSDUtil.h"
 
+#include "AssetToolsModule.h"
+#include "AutomatedAssetImportData.h"
 #include "Components/SplineComponent.h"
 #include "Exporters/Exporter.h"
 #include "IPythonScriptPlugin.h"
@@ -192,4 +194,16 @@ bool Mythica::ExportSpline(AActor* SplineActor, const FString& ExportPath, const
     Stage.GetRootLayer().Save();
 
     return ConvertUSDtoUSDZ(USDPath, ExportPath);
+}
+
+bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory)
+{
+    UAutomatedAssetImportData* ImportData = NewObject<UAutomatedAssetImportData>();
+    ImportData->bReplaceExisting = true;
+    ImportData->DestinationPath = ImportDirectory;
+    ImportData->Filenames = { FilePath };
+
+    FAssetToolsModule& AssetToolsModule = FModuleManager::GetModuleChecked<FAssetToolsModule>("AssetTools");
+    TArray<UObject*> Objects = AssetToolsModule.Get().ImportAssetsAutomated(ImportData);
+    return Objects.Num() == 1;
 }

--- a/Source/Mythica/Private/MythicaUSDUtil.cpp
+++ b/Source/Mythica/Private/MythicaUSDUtil.cpp
@@ -224,7 +224,7 @@ bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory
         true,  /* bCollectMetadata */
         true,  /* bCollectFromEntireSubtrees */
         false, /* bCollectOnComponents */
-        {},	   /* BlockedPrefixFilters */
+        {},    /* BlockedPrefixFilters */
         false  /* bInvertFilters */
     };
     ImportOptions->bOverrideStageOptions = false;

--- a/Source/Mythica/Private/MythicaUSDUtil.h
+++ b/Source/Mythica/Private/MythicaUSDUtil.h
@@ -5,4 +5,6 @@ namespace Mythica
     bool ExportMesh(UStaticMesh* Mesh, const FString& ExportPath);
     bool ExportActors(const TArray<AActor*> Actors, const FString& ExportPath, const FVector& Origin);
     bool ExportSpline(AActor* SplineActor, const FString& ExportPath, const FVector& Origin);
+
+    bool ImportMesh(const FString& FilePath, const FString& ImportDirectory);
 }


### PR DESCRIPTION
This change fixes two bugs:
- Importing a mesh would sometimes spawn an extra instance of that mesh at the origin.
- Importing a mesh would create empty level sequence UAssets

Previously it was importing using the default USD import settings. This was causing some undesired behavior such as "bImportActors" defaulting to true, which is what causes it to automatically add an instance of that mesh to the level.

The default USD import settings also change based on whatever settings you used for the last import. This can cause some of these issues to appear inconsistently if you had manually imported a USD file and turned them off.

Preventing all of these issues by just making it explicitly specify the USD import settings and not using the defaults. The "ImportAssetsAutomated" code path didn't support this, so I had to also change it to the slightly different interface "ImportAssetTasks" which does support it.