### PR TITLE
Polish pass over UAsset management

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -58,8 +58,10 @@ void UMythicaComponent::RegenerateMesh()
         return;
     }
 
+    FString ImportName = ComponentGUID.ToString();
+
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
-    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Inputs, Parameters, "GeneratedMesh", K2_GetComponentLocation());
+    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Inputs, Parameters, ImportName, K2_GetComponentLocation());
 
     if (RequestId > 0)
     {

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -7,6 +7,13 @@ UMythicaComponent::UMythicaComponent()
     PrimaryComponentTick.bCanEverTick = false;
 }
 
+void UMythicaComponent::OnComponentCreated()
+{
+    Super::OnComponentCreated();
+
+    ComponentGUID = FGuid::NewGuid();
+}
+
 void UMythicaComponent::PostLoad()
 {
     Super::PostLoad();

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -2,6 +2,8 @@
 
 #include "AssetRegistry/AssetRegistryModule.h"
 
+#define IMPORT_NAME_LENGTH 10
+
 UMythicaComponent::UMythicaComponent()
 {
     PrimaryComponentTick.bCanEverTick = false;
@@ -58,15 +60,18 @@ void UMythicaComponent::RegenerateMesh()
         return;
     }
 
-    FString ImportName = ComponentGUID.ToString();
-
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
-    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Inputs, Parameters, ImportName, K2_GetComponentLocation());
+    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Inputs, Parameters, GetImportName(), K2_GetComponentLocation());
 
     if (RequestId > 0)
     {
         MythicaEditorSubsystem->OnJobStateChange.AddDynamic(this, &UMythicaComponent::OnJobStateChanged);
     }
+}
+
+FString UMythicaComponent::GetImportName()
+{
+    return ComponentGUID.ToString().Left(IMPORT_NAME_LENGTH);
 }
 
 void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -20,6 +20,7 @@ public:
 
     bool CanRegenerateMesh() const;
     void RegenerateMesh();
+    FString GetImportName();
     EMythicaJobState GetJobState() const { return State; }
 
     virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -15,7 +15,8 @@ public:
     UMythicaComponent();
 
     virtual void PostLoad() override;
-    void OnComponentDestroyed(bool bDestroyingHierarchy);
+    virtual void OnComponentCreated() override;
+    virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
 
     bool CanRegenerateMesh() const;
     void RegenerateMesh();
@@ -65,4 +66,7 @@ private:
 
     UPROPERTY()
     TArray<FName> MeshComponentNames;
+
+    UPROPERTY(DuplicateTransient)
+    FGuid ComponentGUID;
 };

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -1217,24 +1217,6 @@ void UMythicaEditorSubsystem::OnMeshDownloadResponse(FHttpRequestPtr Request, FH
         return;
     }
 
-    // Save the imported assets
-    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
-
-    TArray<FAssetData> Assets;
-    AssetRegistryModule.Get().GetAssetsByPath(*ImportDirectory, Assets, true, false);
-
-    TArray<UPackage*> Packages;
-    for (const FAssetData& Asset : Assets)
-    {
-        Packages.Add(Asset.GetPackage());
-    }
-
-    bool PrevSilent = GIsSilent;
-    GIsSilent = true;
-    UEditorLoadingAndSavingUtils::SavePackages(Packages, true);
-    FTimerHandle DummyHandle;
-    GEditor->GetTimerManager()->SetTimer(DummyHandle, [=]() { GIsSilent = PrevSilent; }, 0.1f, false); // Delay until after asset validation
-
     RequestData->ImportDirectory = ImportDirectory;
     SetJobState(RequestId, EMythicaJobState::Completed);
 

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -151,7 +151,7 @@ struct FMythicaJob
     FMythicaParameters Params;
 
     UPROPERTY()
-    FString ImportName;
+    FString ImportPath;
 
     UPROPERTY()
     EMythicaJobState State = EMythicaJobState::Requesting;


### PR DESCRIPTION
- Mesh UAssets are now stored on a per-component basis.
- Recooking a component will re-import over the existing mesh UAsset.
- Don't immediately save UAssets on import (Avoid large Perforce stalls).