### PR TITLE
Fix visuals not updating when re-importing USD

### DIFF
--- a/Source/Mythica/Private/MythicaUSDUtil.cpp
+++ b/Source/Mythica/Private/MythicaUSDUtil.cpp
@@ -382,19 +382,21 @@ bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory
     }
 
     // Repair references to the original asset in the active level
-    ULevel* Level = GWorld->GetCurrentLevel();
-
-    constexpr EArchiveReplaceObjectFlags
-        ReplaceFlags = (EArchiveReplaceObjectFlags::IgnoreOuterRef | EArchiveReplaceObjectFlags::IgnoreArchetypeRef | EArchiveReplaceObjectFlags::TrackReplacedReferences);
-    FArchiveReplaceObjectRef<UObject> ArchiveReplaceObjectRefInner(Level, AssetReplacementMap, ReplaceFlags);
-
-    // Update render state of repaired references
-    for (const TPair<UObject*, TArray<FProperty*>>& Reference : ArchiveReplaceObjectRefInner.GetReplacedReferences())
+    ULevel* CurrentLevel = GWorld->GetCurrentLevel();
+    if (CurrentLevel)
     {
-        UActorComponent* ReplacedComponent = Cast<UActorComponent>(Reference.Key);
-        if (ReplacedComponent)
+        constexpr EArchiveReplaceObjectFlags
+            ReplaceFlags = (EArchiveReplaceObjectFlags::IgnoreOuterRef | EArchiveReplaceObjectFlags::IgnoreArchetypeRef | EArchiveReplaceObjectFlags::TrackReplacedReferences);
+        FArchiveReplaceObjectRef<UObject> ArchiveReplaceObjectRefInner(CurrentLevel, AssetReplacementMap, ReplaceFlags);
+
+        // Update render state of repaired references
+        for (const TPair<UObject*, TArray<FProperty*>>& Reference : ArchiveReplaceObjectRefInner.GetReplacedReferences())
         {
-            ReplacedComponent->MarkRenderStateDirty();
+            UActorComponent* UpdatedComponent = Cast<UActorComponent>(Reference.Key);
+            if (UpdatedComponent)
+            {
+                UpdatedComponent->MarkRenderStateDirty();
+            }
         }
     }
 

--- a/Source/Mythica/Private/MythicaUSDUtil.cpp
+++ b/Source/Mythica/Private/MythicaUSDUtil.cpp
@@ -3,6 +3,7 @@
 #include "MythicaUSDUtil.h"
 
 #include "AssetImportTask.h"
+#include "AssetRegistry/AssetRegistryModule.h"
 #include "AssetToolsModule.h"
 #include "AutomatedAssetImportData.h"
 #include "Components/SplineComponent.h"
@@ -10,6 +11,7 @@
 #include "IPythonScriptPlugin.h"
 #include "LevelExporterUSDOptions.h"
 #include "Selection.h"
+#include "Serialization/ArchiveReplaceObjectRef.h"
 #include "StaticMeshExporterUSDOptions.h"
 #include "UObject/GCObjectScopeGuard.h"
 #include "UnrealUSDWrapper.h"
@@ -284,6 +286,21 @@ bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory
         return false;
     }
 
+    // Gather set of existing assets
+    FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+
+    FString FileName = FPaths::GetBaseFilename(FilePath);
+    FString CreatedImportDirectory = FPaths::Combine(ImportDirectory, FileName);
+
+    TArray<FAssetData> OriginalAssets;
+    AssetRegistryModule.Get().GetAssetsByPath(*CreatedImportDirectory, OriginalAssets, true, false);
+
+    TMap<FName, UObject*> OriginalAssetMap;
+    for (const FAssetData& Asset : OriginalAssets)
+    {
+        OriginalAssetMap.Add(Asset.PackageName, Asset.GetAsset());
+    }
+
     // Setup import options
     UUsdStageImportOptions* ImportOptions = NewObject<UUsdStageImportOptions>();
     FGCObjectScopeGuard OptionsGuard(ImportOptions);
@@ -347,6 +364,39 @@ bool Mythica::ImportMesh(const FString& FilePath, const FString& ImportDirectory
     GIsSilent = true;
     AssetToolsModule.Get().ImportAssetTasks(Tasks);
     GIsSilent = PrevSilent;
+
+    // Determine which assets were reimported
+    TArray<FAssetData> NewAssets;
+    AssetRegistryModule.Get().GetAssetsByPath(*CreatedImportDirectory, NewAssets, true, false);
+
+    TMap<UObject*, UObject*> AssetReplacementMap;
+    for (const FAssetData& Asset : NewAssets)
+    {
+        UObject* NewAssetObject = Asset.GetAsset();
+        FName NewAssetName = NewAssetObject->GetPackage()->GetFName();
+        if (OriginalAssetMap.Contains(NewAssetName))
+        {
+            UObject* OriginalAssetObject = OriginalAssetMap[NewAssetName];
+            AssetReplacementMap.Add(OriginalAssetObject, NewAssetObject);
+        }
+    }
+
+    // Repair references to the original asset in the active level
+    ULevel* Level = GWorld->GetCurrentLevel();
+
+    constexpr EArchiveReplaceObjectFlags
+        ReplaceFlags = (EArchiveReplaceObjectFlags::IgnoreOuterRef | EArchiveReplaceObjectFlags::IgnoreArchetypeRef | EArchiveReplaceObjectFlags::TrackReplacedReferences);
+    FArchiveReplaceObjectRef<UObject> ArchiveReplaceObjectRefInner(Level, AssetReplacementMap, ReplaceFlags);
+
+    // Update render state of repaired references
+    for (const TPair<UObject*, TArray<FProperty*>>& Reference : ArchiveReplaceObjectRefInner.GetReplacedReferences())
+    {
+        UActorComponent* ReplacedComponent = Cast<UActorComponent>(Reference.Key);
+        if (ReplacedComponent)
+        {
+            ReplacedComponent->MarkRenderStateDirty();
+        }
+    }
 
     return Task->GetObjects().Num() > 0;
 }


### PR DESCRIPTION
When re-importing a static mesh from a USD file, the visuals wouldn't update in the level until you reloaded the level. It would also fail to update references to the static mesh asset correctly, leaving behind a reference to an old transient object.

The root cause of this is an issue with the logic inside of the USD importer. The implementation assumes that the imported assets will only be used in the level by the automatically created import actor created by the "bImportActors" option. If you have that option turned off, it will omit scanning the level for any references to repair. Our plugin doesn't use this option, so it was failing to run this scan.

See:
UE::USDStageImporter::Private::SetupSceneActor
UE::USDStageImporter::Private::RemapReferences
UE::USDStageImporter::Private::RemapSoftReferences

There doesn't appear to be any options in the importer settings to modify this behavior. To work around the issue, I have recreated this reference repair logic in our own code.

This current implementation only updates hard references. I haven't hit a case yet where there is a soft reference that needs to be updated. Once we do we can also try to recreate the logic from "UE::USDStageImporter::Private::RemapSoftReferences" in our code.