### PR TITLE
Fix format parameter from showing in UI

### DIFF
--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -52,6 +52,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
     for (int32 ParamIndex = 0; ParamIndex < Parameters->Parameters.Num(); ++ParamIndex)
     {
         const FMythicaParameter& Parameter = Parameters->Parameters[ParamIndex];
+        if (Mythica::IsSystemParameter(Parameter.Name))
+        {
+            continue;
+        }
 
         TSharedRef<SWidget> ValueWidget = SNullWidget::NullWidget;
         int DesiredWidthScalar = 1;

--- a/Source/Mythica/Private/MythicaTypes.cpp
+++ b/Source/Mythica/Private/MythicaTypes.cpp
@@ -2,6 +2,23 @@
 
 #include "MythicaTypes.h"
 
+const TCHAR* SystemParameters[] =
+{
+    TEXT("format")
+};
+
+bool Mythica::IsSystemParameter(const FString& Name)
+{
+    for (const TCHAR* Parameter : SystemParameters)
+    {
+        if (Name == Parameter)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythicaInputs& OutInputs, FMythicaParameters& OutParameters)
 {
     for (auto It = ParamsSchema->Values.CreateConstIterator(); It; ++It)

--- a/Source/Mythica/Private/MythicaTypes.h
+++ b/Source/Mythica/Private/MythicaTypes.h
@@ -194,6 +194,8 @@ struct FMythicaMaterialParameters
 
 namespace Mythica
 {
+    bool IsSystemParameter(const FString& Name);
+
     void ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythicaInputs& OutInputs, FMythicaParameters& OutParameters);
     void WriteParameters(const FMythicaInputs& Inputs, const TArray<FString>& InputFileIds, const FMythicaParameters& Parameters, const TSharedPtr<FJsonObject>& ParameterSet);
 }


### PR DESCRIPTION
This assumes the default value is the correct value we want (usdz). We can make this logic more complicated when it becomes necessary.

Another solution here would be for a job request to not require you to specify parameters that have a default value. If we did that, we could just drop this parameter in Mythica::ReadParameters similar to what we do for constant parameters.