### PR TITLE
Add whitelist option for tool selector display

### DIFF
--- a/Source/Mythica/Private/MythicaDeveloperSettings.cpp
+++ b/Source/Mythica/Private/MythicaDeveloperSettings.cpp
@@ -1,8 +1,20 @@
 #include "MythicaDeveloperSettings.h"
 
+const TCHAR* DefaultJobDefIdWhitelist[] =
+{
+    TEXT("jobdef_2crsbDnsSuFXgZouExzetpMDyDNq"),    // Crystal
+    TEXT("jobdef_2ksoWHctAoAFcNN5roDzmSZ9iN62"),    // MeanderingVine
+    TEXT("jobdef_3o41eujjxzNCSiMWkEXteaeUEEEM"),    // Rockify
+};
+
 UMythicaDeveloperSettings::UMythicaDeveloperSettings(const FObjectInitializer& ObjectInitializer)
     : Super(ObjectInitializer)
 {
     CategoryName = TEXT("Plugins");
     SectionName = TEXT("Mythica");
+
+    for (const TCHAR* JobDefId : DefaultJobDefIdWhitelist)
+    {
+        JobDefIdWhitelist.Add(JobDefId);
+    }
 }

--- a/Source/Mythica/Private/MythicaDeveloperSettings.h
+++ b/Source/Mythica/Private/MythicaDeveloperSettings.h
@@ -25,5 +25,8 @@ public:
     FString APIKey;
 
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = Tools)
+    bool UseToolWhitelist = true;
+
+    UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = Tools, meta = (EditCondition = "UseToolWhitelist", EditConditionHides))
     TArray<FString> JobDefIdWhitelist;
 };

--- a/Source/Mythica/Private/MythicaDeveloperSettings.h
+++ b/Source/Mythica/Private/MythicaDeveloperSettings.h
@@ -23,4 +23,7 @@ public:
 
     UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = User)
     FString APIKey;
+
+    UPROPERTY(Config, EditAnywhere, BlueprintReadOnly, Category = Tools)
+    TArray<FString> JobDefIdWhitelist;
 };

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -152,7 +152,7 @@ TArray<FMythicaJobDefinition> UMythicaEditorSubsystem::GetJobDefinitionList(cons
             continue;
         }
 
-        if (Settings->JobDefIdWhitelist.IsEmpty() || Settings->JobDefIdWhitelist.Contains(Definition.JobDefId))
+        if (!Settings->UseToolWhitelist || Settings->JobDefIdWhitelist.Contains(Definition.JobDefId))
         {
             Definitions.Add(Definition);
         }

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -142,10 +142,17 @@ TArray<FMythicaAsset> UMythicaEditorSubsystem::GetAssetList()
 
 TArray<FMythicaJobDefinition> UMythicaEditorSubsystem::GetJobDefinitionList(const FString& JobType)
 {
+    UMythicaDeveloperSettings* Settings = GetMutableDefault<UMythicaDeveloperSettings>();
+
     TArray<FMythicaJobDefinition> Definitions;
     for (const FMythicaJobDefinition& Definition : JobDefinitionList)
     {
-        if (Definition.JobType == JobType)
+        if (Definition.JobType != JobType)
+        {
+            continue;
+        }
+
+        if (Settings->JobDefIdWhitelist.IsEmpty() || Settings->JobDefIdWhitelist.Contains(Definition.JobDefId))
         {
             Definitions.Add(Definition);
         }


### PR DESCRIPTION
This is a temporary solution until we build more infrastructure around discoverability and filtering of tools.

Having a hard coded list is bad but will work for the short term. As a mitigation there is a option to disable the whitelist behavior and display the full list.