### PR TITLE
Add reset to default button for parameters

### DIFF
--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -145,6 +145,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                         {
                             FloatParam.Values[i] = FloatParam.DefaultValues[i];
                         }
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
 
                     return FReply::Handled();
@@ -230,6 +231,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                         {
                             IntParam.Values[i] = IntParam.DefaultValues[i];
                         }
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
 
                     return FReply::Handled();
@@ -284,6 +286,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     {
                         FMythicaParameterBool& BoolParam = Parameters->Parameters[ParamIndex].ValueBool;
                         BoolParam.Value = BoolParam.DefaultValue;
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
 
                     return FReply::Handled();
@@ -336,6 +339,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     {
                         FMythicaParameterString& StringParam = Parameters->Parameters[ParamIndex].ValueString;
                         StringParam.Value = StringParam.DefaultValue;
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
 
                     return FReply::Handled();
@@ -430,6 +434,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     {
                         FMythicaParameterEnum& EnumParam = Parameters->Parameters[ParamIndex].ValueEnum;
                         EnumParam.Value = EnumParam.DefaultValue;
+                        HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
 
                     return FReply::Handled();

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -58,6 +58,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
         }
 
         TSharedRef<SWidget> ValueWidget = SNullWidget::NullWidget;
+        TSharedRef<SWidget> ExtensionWidget = SNullWidget::NullWidget;
         int DesiredWidthScalar = 1;
 
         switch (Parameter.Type)
@@ -109,6 +110,49 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                                 .MaxSliderValue(Parameter.ValueFloat.MaxValue)
                         ];
                 }
+
+                auto ResetToDefaultVisible = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        const FMythicaParameterFloat& FloatParam = Parameters->Parameters[ParamIndex].ValueFloat;
+                        for (int i = 0; i < FloatParam.Values.Num(); ++i)
+                        {
+                            if (FloatParam.Values[i] != FloatParam.DefaultValues[i])
+                            {
+                                return EVisibility::Visible;
+                            }
+                        }
+                    }
+
+                    return EVisibility::Collapsed;
+                };
+
+                auto OnResetToDefault = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        FMythicaParameterFloat& FloatParam = Parameters->Parameters[ParamIndex].ValueFloat;
+                        for (int i = 0; i < FloatParam.Values.Num(); ++i)
+                        {
+                            FloatParam.Values[i] = FloatParam.DefaultValues[i];
+                        }
+                    }
+
+                    return FReply::Handled();
+                };
+
+                ExtensionWidget = SNew(SButton)
+                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
+                    .ContentPadding(0)
+                    .Visibility_Lambda(ResetToDefaultVisible)
+                    .OnClicked_Lambda(OnResetToDefault)
+                    [
+                        SNew(SImage)
+                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
+                    ];
 
                 ValueWidget = HorizontalBox;
                 DesiredWidthScalar = Parameter.ValueFloat.Values.Num();
@@ -162,6 +206,49 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                         ];
                 }
 
+                auto ResetToDefaultVisible = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        const FMythicaParameterInt& IntParam = Parameters->Parameters[ParamIndex].ValueInt;
+                        for (int i = 0; i < IntParam.Values.Num(); ++i)
+                        {
+                            if (IntParam.Values[i] != IntParam.DefaultValues[i])
+                            {
+                                return EVisibility::Visible;
+                            }
+                        }
+                    }
+
+                    return EVisibility::Collapsed;
+                };
+
+                auto OnResetToDefault = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        FMythicaParameterInt& IntParam = Parameters->Parameters[ParamIndex].ValueInt;
+                        for (int i = 0; i < IntParam.Values.Num(); ++i)
+                        {
+                            IntParam.Values[i] = IntParam.DefaultValues[i];
+                        }
+                    }
+
+                    return FReply::Handled();
+                };
+
+                ExtensionWidget = SNew(SButton)
+                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
+                    .ContentPadding(0)
+                    .Visibility_Lambda(ResetToDefaultVisible)
+                    .OnClicked_Lambda(OnResetToDefault)
+                    [
+                        SNew(SImage)
+                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
+                    ];
+
                 ValueWidget = HorizontalBox;
                 DesiredWidthScalar = Parameter.ValueInt.Values.Num();
                 break;
@@ -191,6 +278,43 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                 ValueWidget = SNew(SCheckBox)
                     .IsChecked_Lambda(IsChecked)
                     .OnCheckStateChanged_Lambda(OnCheckStateChanged);
+
+                auto ResetToDefaultVisible = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        const FMythicaParameterBool& BoolParam = Parameters->Parameters[ParamIndex].ValueBool;
+                        if (BoolParam.Value != BoolParam.DefaultValue)
+                        {
+                            return EVisibility::Visible;
+                        }
+                    }
+
+                    return EVisibility::Collapsed;
+                };
+
+                auto OnResetToDefault = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        FMythicaParameterBool& BoolParam = Parameters->Parameters[ParamIndex].ValueBool;
+                        BoolParam.Value = BoolParam.DefaultValue;
+                    }
+
+                    return FReply::Handled();
+                };
+
+                ExtensionWidget = SNew(SButton)
+                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
+                    .ContentPadding(0)
+                    .Visibility_Lambda(ResetToDefaultVisible)
+                    .OnClicked_Lambda(OnResetToDefault)
+                    [
+                        SNew(SImage)
+                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
+                    ];
                 break;
             }
             case EMythicaParameterType::String:
@@ -216,6 +340,43 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     .OnTextCommitted_Lambda(OnTextCommitted)
                     .AutoWrapText(true);
                 DesiredWidthScalar = 3;
+
+                auto ResetToDefaultVisible = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        const FMythicaParameterString& StringParam = Parameters->Parameters[ParamIndex].ValueString;
+                        if (StringParam.Value != StringParam.DefaultValue)
+                        {
+                            return EVisibility::Visible;
+                        }
+                    }
+
+                    return EVisibility::Collapsed;
+                };
+
+                auto OnResetToDefault = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        FMythicaParameterString& StringParam = Parameters->Parameters[ParamIndex].ValueString;
+                        StringParam.Value = StringParam.DefaultValue;
+                    }
+
+                    return FReply::Handled();
+                };
+
+                ExtensionWidget = SNew(SButton)
+                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
+                    .ContentPadding(0)
+                    .Visibility_Lambda(ResetToDefaultVisible)
+                    .OnClicked_Lambda(OnResetToDefault)
+                    [
+                        SNew(SImage)
+                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
+                    ];
                 break;
             }
             case EMythicaParameterType::Enum:
@@ -283,6 +444,43 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                         SNew(STextBlock)
                             .Text_Lambda(GetCurrentText)
                     ];
+
+                auto ResetToDefaultVisible = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        const FMythicaParameterEnum& EnumParam = Parameters->Parameters[ParamIndex].ValueEnum;
+                        if (EnumParam.Value != EnumParam.DefaultValue)
+                        {
+                            return EVisibility::Visible;
+                        }
+                    }
+
+                    return EVisibility::Collapsed;
+                };
+
+                auto OnResetToDefault = [this, ParamIndex]()
+                {
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    if (Parameters)
+                    {
+                        FMythicaParameterEnum& EnumParam = Parameters->Parameters[ParamIndex].ValueEnum;
+                        EnumParam.Value = EnumParam.DefaultValue;
+                    }
+
+                    return FReply::Handled();
+                };
+
+                ExtensionWidget = SNew(SButton)
+                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
+                    .ContentPadding(0)
+                    .Visibility_Lambda(ResetToDefaultVisible)
+                    .OnClicked_Lambda(OnResetToDefault)
+                    [
+                        SNew(SImage)
+                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
+                    ];
                 break;
             }
         }
@@ -297,6 +495,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
             .MinDesiredWidth(DesiredWidthScalar * 128)
             [
                 ValueWidget
+            ].
+            ExtensionContent()
+            [
+                ExtensionWidget
             ];
     }
 }

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -6,6 +6,8 @@
 #include "Widgets/Text/SMultiLineEditableText.h"
 #include "Widgets/Input/SNumericEntryBox.h"
 
+#include <functional>
+
 static FMythicaParameters* GetParametersFromHandle(IPropertyHandle& Handle)
 {
     TArray<UObject*> Objects;
@@ -58,8 +60,9 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
         }
 
         TSharedRef<SWidget> ValueWidget = SNullWidget::NullWidget;
-        TSharedRef<SWidget> ExtensionWidget = SNullWidget::NullWidget;
         int DesiredWidthScalar = 1;
+        std::function<EVisibility()> ResetToDefaultVisible;
+        std::function<FReply()> OnResetToDefault;
 
         switch (Parameter.Type)
         {
@@ -111,7 +114,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                         ];
                 }
 
-                auto ResetToDefaultVisible = [this, ParamIndex]()
+                ValueWidget = HorizontalBox;
+                DesiredWidthScalar = Parameter.ValueFloat.Values.Num();
+
+                ResetToDefaultVisible = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -129,7 +135,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     return EVisibility::Collapsed;
                 };
 
-                auto OnResetToDefault = [this, ParamIndex]()
+                OnResetToDefault = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -143,19 +149,6 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                     return FReply::Handled();
                 };
-
-                ExtensionWidget = SNew(SButton)
-                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
-                    .ContentPadding(0)
-                    .Visibility_Lambda(ResetToDefaultVisible)
-                    .OnClicked_Lambda(OnResetToDefault)
-                    [
-                        SNew(SImage)
-                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
-                    ];
-
-                ValueWidget = HorizontalBox;
-                DesiredWidthScalar = Parameter.ValueFloat.Values.Num();
                 break;
             }
             case EMythicaParameterType::Int:
@@ -206,7 +199,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                         ];
                 }
 
-                auto ResetToDefaultVisible = [this, ParamIndex]()
+                ValueWidget = HorizontalBox;
+                DesiredWidthScalar = Parameter.ValueInt.Values.Num();
+
+                ResetToDefaultVisible = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -224,7 +220,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     return EVisibility::Collapsed;
                 };
 
-                auto OnResetToDefault = [this, ParamIndex]()
+                OnResetToDefault = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -238,19 +234,6 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                     return FReply::Handled();
                 };
-
-                ExtensionWidget = SNew(SButton)
-                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
-                    .ContentPadding(0)
-                    .Visibility_Lambda(ResetToDefaultVisible)
-                    .OnClicked_Lambda(OnResetToDefault)
-                    [
-                        SNew(SImage)
-                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
-                    ];
-
-                ValueWidget = HorizontalBox;
-                DesiredWidthScalar = Parameter.ValueInt.Values.Num();
                 break;
             }
             case EMythicaParameterType::Bool:
@@ -279,7 +262,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     .IsChecked_Lambda(IsChecked)
                     .OnCheckStateChanged_Lambda(OnCheckStateChanged);
 
-                auto ResetToDefaultVisible = [this, ParamIndex]()
+                ResetToDefaultVisible = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -294,7 +277,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     return EVisibility::Collapsed;
                 };
 
-                auto OnResetToDefault = [this, ParamIndex]()
+                OnResetToDefault = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -305,16 +288,6 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                     return FReply::Handled();
                 };
-
-                ExtensionWidget = SNew(SButton)
-                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
-                    .ContentPadding(0)
-                    .Visibility_Lambda(ResetToDefaultVisible)
-                    .OnClicked_Lambda(OnResetToDefault)
-                    [
-                        SNew(SImage)
-                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
-                    ];
                 break;
             }
             case EMythicaParameterType::String:
@@ -341,7 +314,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     .AutoWrapText(true);
                 DesiredWidthScalar = 3;
 
-                auto ResetToDefaultVisible = [this, ParamIndex]()
+                ResetToDefaultVisible = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -356,7 +329,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     return EVisibility::Collapsed;
                 };
 
-                auto OnResetToDefault = [this, ParamIndex]()
+                OnResetToDefault = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -367,16 +340,6 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                     return FReply::Handled();
                 };
-
-                ExtensionWidget = SNew(SButton)
-                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
-                    .ContentPadding(0)
-                    .Visibility_Lambda(ResetToDefaultVisible)
-                    .OnClicked_Lambda(OnResetToDefault)
-                    [
-                        SNew(SImage)
-                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
-                    ];
                 break;
             }
             case EMythicaParameterType::Enum:
@@ -445,7 +408,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                             .Text_Lambda(GetCurrentText)
                     ];
 
-                auto ResetToDefaultVisible = [this, ParamIndex]()
+                ResetToDefaultVisible = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -460,7 +423,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     return EVisibility::Collapsed;
                 };
 
-                auto OnResetToDefault = [this, ParamIndex]()
+                OnResetToDefault = [this, ParamIndex]()
                 {
                     FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
                     if (Parameters)
@@ -471,16 +434,6 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                     return FReply::Handled();
                 };
-
-                ExtensionWidget = SNew(SButton)
-                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
-                    .ContentPadding(0)
-                    .Visibility_Lambda(ResetToDefaultVisible)
-                    .OnClicked_Lambda(OnResetToDefault)
-                    [
-                        SNew(SImage)
-                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
-                    ];
                 break;
             }
         }
@@ -498,7 +451,15 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
             ].
             ExtensionContent()
             [
-                ExtensionWidget
+                SNew(SButton)
+                    .ButtonStyle(FAppStyle::Get(), "NoBorder")
+                    .ContentPadding(0)
+                    .Visibility_Lambda(ResetToDefaultVisible)
+                    .OnClicked_Lambda(OnResetToDefault)
+                    [
+                        SNew(SImage)
+                            .Image(FAppStyle::Get().GetBrush("PropertyWindow.DiffersFromDefault"))
+                    ]
             ];
     }
 }


### PR DESCRIPTION
I couldn't figure out how to make the button appear in the right column of the detail view panel like the regular property editor. Adding it to the extension section makes it look close to correct so I used that for now.