### PR TITLE
Fix Mythica component not working in actor blueprints

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -134,16 +134,17 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
 {
     Super::PostEditChangeProperty(PropertyChangedEvent);
 
+    if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, JobDefId))
+    {
+        OnJobDefIdChanged();
+    }
+
     if (!CanRegenerateMesh())
     {
         return;
     }
 
-    if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, JobDefId))
-    {
-        OnJobDefIdChanged();
-    }
-    else if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, Parameters))
+    if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, Parameters))
     {
         if (Settings.RegenerateOnParameterChange)
         {
@@ -179,7 +180,9 @@ static void ForceRefreshDetailsViewPanel()
         "LevelEditorSelectionDetails",
         "LevelEditorSelectionDetails2",
         "LevelEditorSelectionDetails3",
-        "LevelEditorSelectionDetails4" 
+        "LevelEditorSelectionDetails4",
+        "BlueprintDefaults",
+        "BlueprintInspector"
     };
 
     for (const FName DetailsPanelName : DetailsTabIdentifiers)

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -25,13 +25,6 @@ UMythicaComponent::UMythicaComponent()
     PrimaryComponentTick.bCanEverTick = false;
 }
 
-void UMythicaComponent::OnComponentCreated()
-{
-    Super::OnComponentCreated();
-
-    ComponentGUID = FGuid::NewGuid();
-}
-
 void UMythicaComponent::PostLoad()
 {
     Super::PostLoad();
@@ -87,6 +80,11 @@ void UMythicaComponent::RegenerateMesh()
     {
         QueueRegenerate = true;
         return;
+    }
+
+    if (!ComponentGUID.IsValid())
+    {
+        ComponentGUID = FGuid::NewGuid();
     }
 
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -30,7 +30,6 @@ public:
     UMythicaComponent();
 
     virtual void PostLoad() override;
-    virtual void OnComponentCreated() override;
     virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
     virtual void OnRegister() override;
 
@@ -92,6 +91,6 @@ private:
     UPROPERTY(VisibleAnywhere, meta = (EditCondition = "false", EditConditionHides))
     TArray<FName> MeshComponentNames;
 
-    UPROPERTY(VisibleAnywhere, meta = (EditCondition = "false", EditConditionHides))
+    UPROPERTY(VisibleAnywhere, DuplicateTransient, meta = (EditCondition = "false", EditConditionHides))
     FGuid ComponentGUID;
 };

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -59,7 +59,7 @@ private:
     void UpdatePlaceholderMesh();
 
 public:
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     FMythicaJobDefinitionId JobDefId;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -80,7 +80,7 @@ private:
     bool QueueRegenerate = false;
     FTimerHandle DelayRegenerateHandle;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere, meta = (EditCondition = "false", EditConditionHides))
     TMap<EMythicaJobState, double> StateDurations;
 
     UPROPERTY(Transient)
@@ -89,9 +89,9 @@ private:
     UPROPERTY(Transient)
     UStaticMeshComponent* PlaceholderMeshComponent = nullptr;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere, meta = (EditCondition = "false", EditConditionHides))
     TArray<FName> MeshComponentNames;
 
-    UPROPERTY(DuplicateTransient)
+    UPROPERTY(VisibleAnywhere, meta = (EditCondition = "false", EditConditionHides))
     FGuid ComponentGUID;
 };

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -72,7 +72,7 @@ struct FMythicaJobDefinitionId
 {
     GENERATED_BODY()
 
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Data")
     FString JobDefId;
 };
 

--- a/Source/Mythica/Private/MythicaTypes.h
+++ b/Source/Mythica/Private/MythicaTypes.h
@@ -62,16 +62,16 @@ struct FMythicaParameterInt
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TArray<int> Values;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TArray<int> DefaultValues;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TOptional<int> MinValue;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TOptional<int> MaxValue;
 };
 
@@ -80,16 +80,16 @@ struct FMythicaParameterFloat
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TArray<float> Values;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TArray<float> DefaultValues;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TOptional<float> MinValue;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TOptional<float> MaxValue;
 };
 
@@ -98,10 +98,10 @@ struct FMythicaParameterBool
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     bool Value = false;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     bool DefaultValue = false;
 };
 
@@ -110,10 +110,10 @@ struct FMythicaParameterString
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString Value;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString DefaultValue;
 };
 
@@ -122,10 +122,10 @@ struct FMythicaParameterEnumValue
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString Name;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString Label;
 };
 
@@ -134,13 +134,13 @@ struct FMythicaParameterEnum
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString Value;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString DefaultValue;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     TArray<FMythicaParameterEnumValue> Values;
 };
 
@@ -149,28 +149,28 @@ struct FMythicaParameter
 {
     GENERATED_BODY()
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString Name;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FString Label;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     EMythicaParameterType Type = EMythicaParameterType::Int;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FMythicaParameterInt ValueInt;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FMythicaParameterFloat ValueFloat;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FMythicaParameterBool ValueBool;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FMythicaParameterString ValueString;
 
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere)
     FMythicaParameterEnum ValueEnum;
 };
 
@@ -179,7 +179,7 @@ struct FMythicaParameters
 {
     GENERATED_BODY()
 
-    UPROPERTY(BlueprintReadOnly, Category = "Parameter")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Parameter")
     TArray<FMythicaParameter> Parameters;
 };
 


### PR DESCRIPTION
There were a number of serialization issues causing actors directly authored in the level to behave differently from those placed with an actor blueprint.

When you have an actor blueprint placed in a level, it will often re-instantiate the base object and de-serialize the instance data back over the new object. (eg. if you modify the base actor blueprint, or if you change the transform of the actor instance)

The issues fixed to make the de-serialize after re-initialization work:
1. This appears to only re-apply data that is visible in the detail view panel. This causing all the parameters like JobDef/Parameters to get lost (they were hidden from the regular panel because there are custom editor UI created for them). Fixed the issue by marking the data as visible, but hiding them at the UI layer with an EditCondition. This is a bit of a hack and unsure if this the cleanest solution.
2. It will only re-apply data that it thinks doesn't conflict with changes in the new re-instantiated base object. This was causing the ComponentGUID to get changed due to it being setup during the component creation process since it though it was not different. Fixed by deferring ComponentGUID allocation until a job is requested.
3. The Parameters list wasn't updating when changing the tool selection in the actor blueprint deteils view panel. This was fixed by changing the logic in PostEditChangeProperty to allow this. The ForceRefreshDetailsViewPanel hack also needed to be extended for the actor blueprint detail view panel for this to work.

With these changes, you can now author an actor blueprint that uses a Mythica component, and then place that actor in a level and generate meshes with it. You still are not able to generate meshes directly inside the actor blueprint editor.

A few minor known issues:
1. If you recompile the base actor blueprint while and instance is executing a job, it will leak that job. This could likely be fixed by making sure more of the variables are Transient serialized.
2. In the actor blueprint, if you modify a parameter those defaults don't propagate to instances of that actor in the level. Not sure the root cause. Something about the logic is making it think that all the parameter variables are modified on the instance.
3. If you copy paste a Mythica component on an instance that was originally authored in a base actor blueprint, it will use the parameter values from the base actor rather than the instance. Not sure the root cause.