### PR TITLE
Support for undo/redo

### DIFF
--- a/Source/Mythica/Private/MythicaComponentDetails.cpp
+++ b/Source/Mythica/Private/MythicaComponentDetails.cpp
@@ -9,6 +9,8 @@
 #include "Widgets/Notifications/SProgressBar.h"
 #include "Widgets/Text/STextBlock.h"
 
+#define LOCTEXT_NAMESPACE "Mythica"
+
 const float ProgressBarHeight = 3.0f;
 
 TSharedRef<IDetailCustomization> FMythicaComponentDetails::MakeInstance()
@@ -239,6 +241,9 @@ void FMythicaComponentDetails::OnSelectionChanged(const FString& NewValue, TWeak
 {
     if (ComponentWeak.IsValid())
     {
+        const FScopedTransaction Transaction(LOCTEXT("MythicaSelectTool", "Select Tool"));
+        ComponentWeak->Modify();
+
         ComponentWeak->JobDefId.JobDefId = NewValue;
 
         FPropertyChangedEvent PropertyChangedEvent(

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -377,9 +377,12 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 auto OnTextCommitted = [this, ParamIndex](const FText& InText, ETextCommit::Type InCommitType)
                 {
-                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    UObject* Object = nullptr;
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak, &Object);
                     if (Parameters)
                     {
+                        const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Changed"));
+                        Object->Modify();
                         Parameters->Parameters[ParamIndex].ValueString.Value = InText.ToString();
                         HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
@@ -408,9 +411,13 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 OnResetToDefault = [this, ParamIndex]()
                 {
-                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    UObject* Object = nullptr;
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak, &Object);
                     if (Parameters)
                     {
+                        const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Reset"));
+                        Object->Modify();
+
                         FMythicaParameterString& StringParam = Parameters->Parameters[ParamIndex].ValueString;
                         StringParam.Value = StringParam.DefaultValue;
                         HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -211,7 +211,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                             if (Value != NewValue)
                             {
                                 Object->Modify();
-                                Parameters->Parameters[ParamIndex].ValueInt.Values[ComponentIndex] = NewValue;
+                                Value = NewValue;
                                 HandleWeak.Pin()->NotifyPostChange(UsingSlider ? EPropertyChangeType::Interactive : EPropertyChangeType::ValueSet);
                             }
                         }
@@ -228,7 +228,7 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                             {
                                 const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Changed"));
                                 Object->Modify();
-                                Parameters->Parameters[ParamIndex].ValueInt.Values[ComponentIndex] = NewValue;
+                                Value = NewValue;
                                 HandleWeak.Pin()->NotifyPostChange(UsingSlider ? EPropertyChangeType::Interactive : EPropertyChangeType::ValueSet);
                             }
                         }

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -319,9 +319,12 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                     if (NewState == ECheckBoxState::Undetermined)
                         return;
 
-                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    UObject* Object = nullptr;
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak, &Object);
                     if (Parameters)
                     {
+                        const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Changed"));
+                        Object->Modify();
                         Parameters->Parameters[ParamIndex].ValueBool.Value = (NewState == ECheckBoxState::Checked);
                         HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
@@ -348,9 +351,13 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 OnResetToDefault = [this, ParamIndex]()
                 {
-                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    UObject* Object = nullptr;
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak, &Object);
                     if (Parameters)
                     {
+                        const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Reset"));
+                        Object->Modify();
+
                         FMythicaParameterBool& BoolParam = Parameters->Parameters[ParamIndex].ValueBool;
                         BoolParam.Value = BoolParam.DefaultValue;
                         HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -452,9 +452,12 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 auto OnSelectionChanged = [this, ParamIndex](TSharedPtr<FMythicaParameterEnumValue> NewSelection, ESelectInfo::Type SelectInfo)
                 {
-                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    UObject* Object = nullptr;
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak, &Object);
                     if (Parameters && NewSelection.IsValid())
                     {
+                        const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Changed"));
+                        Object->Modify();
                         Parameters->Parameters[ParamIndex].ValueEnum.Value = NewSelection->Name;
                         HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);
                     }
@@ -510,9 +513,13 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
 
                 OnResetToDefault = [this, ParamIndex]()
                 {
-                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak);
+                    UObject* Object = nullptr;
+                    FMythicaParameters* Parameters = GetParametersFromHandleWeak(HandleWeak, &Object);
                     if (Parameters)
                     {
+                        const FScopedTransaction Transaction(LOCTEXT("MythicaChangeParameter", "Parameter Value Reset"));
+                        Object->Modify();
+
                         FMythicaParameterEnum& EnumParam = Parameters->Parameters[ParamIndex].ValueEnum;
                         EnumParam.Value = EnumParam.DefaultValue;
                         HandleWeak.Pin()->NotifyPostChange(EPropertyChangeType::ValueSet);


### PR DESCRIPTION
I am not completely sure the slider transactions are setup correctly. If you alt-tab while actively holding the slider, it will fail to call the OnEndSliderMovement function causing the transaction to leak. However this is a pattern that all other instances of this are using and is also a bug that exists in Unreal's core property UI implementation (SPropertyEditorNumeric).

It is also unclear to me how to exactly tell whether OnValueCommitted is called from an user directly typing in a number versus the slider ending. In practice it seems like you can detect this by checking if the value actually needs to be changed (In the slider case, it would have already called OnValueChanged before calling OnValueCommitted). OnValueCommitted is creating a new FScopedTransaction to handle this case.

Another minor improvement here could be to include the parameter name in the transaction description. The standard property UI seems to do that.