### PR TITLE
Fix displaying inputs before tool is selected

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -43,6 +43,8 @@ void UMythicaComponent::OnRegister()
 {
     Super::OnRegister();
 
+    DisplayInputs = !Inputs.Inputs.IsEmpty();
+
     UpdatePlaceholderMesh();
 }
 
@@ -202,6 +204,7 @@ void UMythicaComponent::OnJobDefIdChanged()
     FMythicaJobDefinition Definition = MythicaEditorSubsystem->GetJobDefinitionById(JobDefId.JobDefId);
     Parameters = Definition.Parameters;
     Inputs = Definition.Inputs;
+    DisplayInputs = !Inputs.Inputs.IsEmpty();
 
     State = EMythicaJobState::Invalid;
     StateDurations.Reset();

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -67,7 +67,7 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters")
     FMythicaParameters Parameters;
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters", meta = (EditCondition = "DisplayInputs", EditConditionHides, HideEditConditionToggle))
     FMythicaInputs Inputs;
 
 private:
@@ -78,6 +78,9 @@ private:
 
     bool QueueRegenerate = false;
     FTimerHandle DelayRegenerateHandle;
+
+    UPROPERTY(Transient)
+    bool DisplayInputs = false;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     TMap<EMythicaJobState, double> StateDurations;


### PR DESCRIPTION
Also fixes displaying it for tools that don't use inputs.

The input data representation is planned to be refactored soon which will remove this problem at a more root level. This change can be reverted once that change occurs.