### PR TITLE
Refactor tool input geometry

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -157,17 +157,9 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
                 RegenerateMesh();
             }
         }
+
+        BindWorldInputListeners();
     }
-    /*
-    else if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, Inputs))
-    {
-        if (Settings.RegenerateOnInputChange)
-        {
-            BindWorldInputListeners();
-            RegenerateMesh();
-        }
-    }
-    */
     else if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FMythicaComponentSettings, RegenerateOnInputChange))
     {
         BindWorldInputListeners();
@@ -226,9 +218,14 @@ void UMythicaComponent::BindWorldInputListeners()
         return;
     }
 
-    /*
-    for (FMythicaInput& Input : Inputs.Inputs)
+    for (const FMythicaParameter& Parameter : Parameters.Parameters)
     {
+        if (Parameter.Type != EMythicaParameterType::File)
+        {
+            continue;
+        }
+
+        const FMythicaParameterFile& Input = Parameter.ValueFile;
         if (Input.Type != EMythicaInputType::World)
         {
             continue;
@@ -249,7 +246,6 @@ void UMythicaComponent::BindWorldInputListeners()
             }
         }
     }
-    */
 }
 
 void UMythicaComponent::OnWorldInputTransformUpdated(USceneComponent* InComponent, EUpdateTransformFlags InFlags, ETeleportType InType)

--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -43,8 +43,6 @@ void UMythicaComponent::OnRegister()
 {
     Super::OnRegister();
 
-    DisplayInputs = !Inputs.Inputs.IsEmpty();
-
     UpdatePlaceholderMesh();
 }
 
@@ -90,7 +88,7 @@ void UMythicaComponent::RegenerateMesh()
     }
 
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
-    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Inputs, Parameters, GetImportName(), K2_GetComponentLocation());
+    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Parameters, GetImportName(), K2_GetComponentLocation());
 
     if (RequestId > 0)
     {
@@ -160,6 +158,7 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
             }
         }
     }
+    /*
     else if (PropertyChangedEvent.MemberProperty->GetFName() == GET_MEMBER_NAME_CHECKED(UMythicaComponent, Inputs))
     {
         if (Settings.RegenerateOnInputChange)
@@ -168,6 +167,7 @@ void UMythicaComponent::PostEditChangeProperty(FPropertyChangedEvent& PropertyCh
             RegenerateMesh();
         }
     }
+    */
     else if (PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(FMythicaComponentSettings, RegenerateOnInputChange))
     {
         BindWorldInputListeners();
@@ -203,8 +203,6 @@ void UMythicaComponent::OnJobDefIdChanged()
 
     FMythicaJobDefinition Definition = MythicaEditorSubsystem->GetJobDefinitionById(JobDefId.JobDefId);
     Parameters = Definition.Parameters;
-    Inputs = Definition.Inputs;
-    DisplayInputs = !Inputs.Inputs.IsEmpty();
 
     State = EMythicaJobState::Invalid;
     StateDurations.Reset();
@@ -228,6 +226,7 @@ void UMythicaComponent::BindWorldInputListeners()
         return;
     }
 
+    /*
     for (FMythicaInput& Input : Inputs.Inputs)
     {
         if (Input.Type != EMythicaInputType::World)
@@ -250,6 +249,7 @@ void UMythicaComponent::BindWorldInputListeners()
             }
         }
     }
+    */
 }
 
 void UMythicaComponent::OnWorldInputTransformUpdated(USceneComponent* InComponent, EUpdateTransformFlags InFlags, ETeleportType InType)

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -67,9 +67,6 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters")
     FMythicaParameters Parameters;
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters", meta = (EditCondition = "DisplayInputs", EditConditionHides, HideEditConditionToggle))
-    FMythicaInputs Inputs;
-
 private:
     int RequestId = -1;
     EMythicaJobState State = EMythicaJobState::Invalid;
@@ -78,9 +75,6 @@ private:
 
     bool QueueRegenerate = false;
     FTimerHandle DelayRegenerateHandle;
-
-    UPROPERTY(Transient)
-    bool DisplayInputs = false;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     TMap<EMythicaJobState, double> StateDurations;

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -710,14 +710,19 @@ void UMythicaEditorSubsystem::OnJobDefinitionsResponse(FHttpRequestPtr Request, 
     OnJobDefinitionListUpdated.Broadcast();
 }
 
-bool UMythicaEditorSubsystem::PrepareInputFiles(const FMythicaInputs& Inputs, TMap<int, FString>& InputFiles, FString& ExportDirectory, const FVector& Origin)
+bool UMythicaEditorSubsystem::PrepareInputFiles(const FMythicaParameters& Params, TMap<int, FString>& InputFiles, FString& ExportDirectory, const FVector& Origin)
 {
     FString DesiredDirectory = FPaths::Combine(FPaths::ProjectIntermediateDir(), TEXT("MythicaCache"), TEXT("ExportCache"), TEXT("Export"));
     ExportDirectory = MakeUniquePath(DesiredDirectory);
 
-    for (int i = 0; i < Inputs.Inputs.Num(); i++)
+    for (int i = 0; i < Params.Parameters.Num(); i++)
     {
-        const FMythicaInput& Input = Inputs.Inputs[i];
+        if (Params.Parameters[i].Type != EMythicaParameterType::File)
+        {
+            continue;
+        }
+        
+        const FMythicaParameterFile& Input = Params.Parameters[i].ValueFile;
         if (Input.Type == EMythicaInputType::Mesh)
         {
             if (!Input.Mesh)
@@ -927,7 +932,7 @@ int UMythicaEditorSubsystem::ExecuteJob(
 
     FString ExportDirectory;
     TMap<int, FString> InputFiles;
-    bool Success = PrepareInputFiles(Inputs, InputFiles, ExportDirectory, Origin);
+    bool Success = PrepareInputFiles(Params, InputFiles, ExportDirectory, Origin);
     if (!Success)
     {
         UE_LOG(LogMythica, Error, TEXT("Failed to prepare job input files"));

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -94,9 +94,6 @@ struct FMythicaJobDefinition
     FString Description;
 
     UPROPERTY(BlueprintReadOnly, Category = "Data")
-    FMythicaInputs Inputs;
-
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
     FMythicaParameters Parameters;
 };
 
@@ -140,9 +137,6 @@ struct FMythicaJob
 
     UPROPERTY()
     FString JobDefId;
-
-    UPROPERTY()
-    FMythicaInputs Inputs;
 
     UPROPERTY()
     TArray<FString> InputFileIds;
@@ -228,7 +222,6 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Mythica")
     int ExecuteJob(
         const FString& JobDefId, 
-        const FMythicaInputs& Inputs, 
         const FMythicaParameters& Params, 
         const FString& ImportName, 
         const FVector& Origin);
@@ -273,7 +266,7 @@ private:
     void OnMeshDownloadInfoResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId);
     void OnMeshDownloadResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId);
 
-    int CreateJob(const FString& JobDefId, const FMythicaInputs& Inputs, const FMythicaParameters& Params, const FString& ImportName);
+    int CreateJob(const FString& JobDefId, const FMythicaParameters& Params, const FString& ImportName);
     void SetJobState(int RequestId, EMythicaJobState State, FText Message = FText::GetEmpty());
     void PollJobStatus();
     void OnJobTimeout(int RequestId);

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -263,7 +263,7 @@ private:
 
     void OnJobDefinitionsResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
 
-    bool PrepareInputFiles(const FMythicaInputs& Inputs, TMap<int, FString>& InputFiles, FString& ExportDirectory, const FVector& Origin);
+    bool PrepareInputFiles(const FMythicaParameters& Params, TMap<int, FString>& InputFiles, FString& ExportDirectory, const FVector& Origin);
     void UploadInputFiles(int RequestId, const TMap<int, FString>& InputFiles);
     void OnUploadInputFilesResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId, const TMap<int, FString>& InputFiles);
     void SendJobRequest(int RequestId);

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -531,6 +531,13 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
             }
             case EMythicaParameterType::File:
             {
+                const TSharedPtr<IPropertyHandleArray> ParametersArrayHandle = StructPropertyHandle->GetChildHandle(TEXT("Parameters"))->AsArray();
+                const TSharedPtr<IPropertyHandle> ParametersHandle = ParametersArrayHandle->GetElement(ParamIndex);
+                const TSharedPtr<IPropertyHandle> FileValueHandle = ParametersHandle->GetChildHandle(TEXT("ValueFile"));
+
+                StructBuilder.AddProperty(FileValueHandle.ToSharedRef())
+                    .DisplayName(FText::FromString(Parameter.Label));
+
                 continue;
             }
         }

--- a/Source/Mythica/Private/MythicaParametersDetails.cpp
+++ b/Source/Mythica/Private/MythicaParametersDetails.cpp
@@ -529,6 +529,10 @@ void FMythicaParametersDetails::CustomizeChildren(TSharedRef<IPropertyHandle> St
                 };
                 break;
             }
+            case EMythicaParameterType::File:
+            {
+                continue;
+            }
         }
 
         StructBuilder.AddCustomRow(FText::FromString(Parameter.Label))

--- a/Source/Mythica/Private/MythicaTypes.cpp
+++ b/Source/Mythica/Private/MythicaTypes.cpp
@@ -198,7 +198,6 @@ void Mythica::WriteParameters(const TArray<FString>& InputFileIds, const FMythic
                 break;
 
             case EMythicaParameterType::File:
-
                 FString FileId = InputFileIds.IsValidIndex(i) ? InputFileIds[i] : FString();
 
                 TSharedPtr<FJsonObject> FileObject = MakeShareable(new FJsonObject);

--- a/Source/Mythica/Private/MythicaTypes.cpp
+++ b/Source/Mythica/Private/MythicaTypes.cpp
@@ -19,7 +19,7 @@ bool Mythica::IsSystemParameter(const FString& Name)
     return false;
 }
 
-void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythicaInputs& OutInputs, FMythicaParameters& OutParameters)
+void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythicaParameters& OutParameters)
 {
     for (auto It = ParamsSchema->Values.CreateConstIterator(); It; ++It)
     {
@@ -146,7 +146,7 @@ void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythi
     }
 }
 
-void Mythica::WriteParameters(const FMythicaInputs& Inputs, const TArray<FString>& InputFileIds, const FMythicaParameters& Parameters, const TSharedPtr<FJsonObject>& OutParamsSet)
+void Mythica::WriteParameters(const TArray<FString>& InputFileIds, const FMythicaParameters& Parameters, const TSharedPtr<FJsonObject>& OutParamsSet)
 {
     for (int i = 0; i < Parameters.Parameters.Num(); ++i)
     {

--- a/Source/Mythica/Private/MythicaTypes.cpp
+++ b/Source/Mythica/Private/MythicaTypes.cpp
@@ -47,8 +47,6 @@ void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythi
             int InputIndex = FCString::Atoi(*Matcher.GetCaptureGroup(1));
             OutInputs.Inputs.SetNum(InputIndex + 1, EAllowShrinking::No);
             OutInputs.Inputs[InputIndex] = Input;
-
-            continue;
         }
 
         // Handle Parameters
@@ -148,6 +146,11 @@ void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythi
             Parameter.Type = EMythicaParameterType::Enum;
             Parameter.ValueEnum = FMythicaParameterEnum{ DefaultValue, DefaultValue, Values };
         }
+        else if (Type == "file")
+        {
+            Parameter.Type = EMythicaParameterType::File;
+            Parameter.ValueFile = FMythicaParameterFile{};
+        }
         else
         {
             continue;
@@ -217,6 +220,10 @@ void Mythica::WriteParameters(const FMythicaInputs& Inputs, const TArray<FString
 
             case EMythicaParameterType::Enum:
                 OutParamsSet->SetStringField(Param.Name, Param.ValueEnum.Value);
+                break;
+
+            case EMythicaParameterType::File:
+                OutParamsSet->SetStringField(Param.Name, "file_xxxxxxxxxx");
                 break;
         }
     }

--- a/Source/Mythica/Private/MythicaTypes.cpp
+++ b/Source/Mythica/Private/MythicaTypes.cpp
@@ -35,20 +35,6 @@ void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythi
 
         FString Label = ParameterObject->GetStringField(TEXT("label"));
 
-        // Handle Inputs
-        FRegexPattern Pattern(TEXT("^input(\\d+)$"));
-        FRegexMatcher Matcher(Pattern, Name);
-
-        if (Matcher.FindNext())
-        {
-            FMythicaInput Input;
-            Input.Label = Label;
-
-            int InputIndex = FCString::Atoi(*Matcher.GetCaptureGroup(1));
-            OutInputs.Inputs.SetNum(InputIndex + 1, EAllowShrinking::No);
-            OutInputs.Inputs[InputIndex] = Input;
-        }
-
         // Handle Parameters
         FMythicaParameter Parameter;
         Parameter.Name = Name;
@@ -162,20 +148,9 @@ void Mythica::ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythi
 
 void Mythica::WriteParameters(const FMythicaInputs& Inputs, const TArray<FString>& InputFileIds, const FMythicaParameters& Parameters, const TSharedPtr<FJsonObject>& OutParamsSet)
 {
-    for (int i = 0; i < Inputs.Inputs.Num(); ++i)
+    for (int i = 0; i < Parameters.Parameters.Num(); ++i)
     {
-        const FMythicaInput& Input = Inputs.Inputs[i];
-        
-        FString FileId = InputFileIds.IsValidIndex(i) ? InputFileIds[i] : FString();
-
-        TSharedPtr<FJsonObject> FileObject = MakeShareable(new FJsonObject);
-        FileObject->SetStringField(TEXT("file_id"), FileId);
-
-        OutParamsSet->SetObjectField(FString::Printf(TEXT("input%d"), i), FileObject);
-    }
-
-    for (const FMythicaParameter& Param : Parameters.Parameters)
-    {
+        const FMythicaParameter& Param = Parameters.Parameters[i];
         switch (Param.Type)
         {
             case EMythicaParameterType::Int:
@@ -223,7 +198,13 @@ void Mythica::WriteParameters(const FMythicaInputs& Inputs, const TArray<FString
                 break;
 
             case EMythicaParameterType::File:
-                OutParamsSet->SetStringField(Param.Name, "file_xxxxxxxxxx");
+
+                FString FileId = InputFileIds.IsValidIndex(i) ? InputFileIds[i] : FString();
+
+                TSharedPtr<FJsonObject> FileObject = MakeShareable(new FJsonObject);
+                FileObject->SetStringField(TEXT("file_id"), FileId);
+
+                OutParamsSet->SetObjectField(Param.Name, FileObject);
                 break;
         }
     }

--- a/Source/Mythica/Private/MythicaTypes.h
+++ b/Source/Mythica/Private/MythicaTypes.h
@@ -17,42 +17,6 @@ enum class EMythicaInputType : uint8
     Volume  UMETA(DisplayName = "Volume")
 };
 
-USTRUCT(BlueprintType)
-struct FMythicaInput
-{
-    GENERATED_BODY()
-
-    UPROPERTY(BlueprintReadOnly, VisibleAnywhere, Category = "Input")
-    FString Label;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input")
-    EMythicaInputType Type = EMythicaInputType::Mesh;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input", meta = (EditCondition = "Type != EMythicaInputType::Mesh", EditConditionHides))
-    EMythicaExportTransformType TransformType = EMythicaExportTransformType::Relative;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input", meta = (EditCondition = "Type == EMythicaInputType::Mesh", EditConditionHides))
-    UStaticMesh* Mesh = nullptr;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input", meta = (EditCondition = "Type == EMythicaInputType::World", EditConditionHides))
-    TArray<AActor*> Actors;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input", meta = (EditCondition = "Type == EMythicaInputType::Spline", EditConditionHides))
-    AActor* SplineActor = nullptr;
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input", meta = (EditCondition = "Type == EMythicaInputType::Volume", EditConditionHides))
-    AMythicaInputSelectionVolume* VolumeActor = nullptr;
-};
-
-USTRUCT(BlueprintType)
-struct FMythicaInputs
-{
-    GENERATED_BODY()
-
-    UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Input")
-    TArray<FMythicaInput> Inputs;
-};
-
 UENUM()
 enum class EMythicaParameterType : uint8
 {
@@ -230,6 +194,6 @@ namespace Mythica
 {
     bool IsSystemParameter(const FString& Name);
 
-    void ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythicaInputs& OutInputs, FMythicaParameters& OutParameters);
-    void WriteParameters(const FMythicaInputs& Inputs, const TArray<FString>& InputFileIds, const FMythicaParameters& Parameters, const TSharedPtr<FJsonObject>& ParameterSet);
+    void ReadParameters(const TSharedPtr<FJsonObject>& ParamsSchema, FMythicaParameters& OutParameters);
+    void WriteParameters(const TArray<FString>& InputFileIds, const FMythicaParameters& Parameters, const TSharedPtr<FJsonObject>& ParameterSet);
 }

--- a/Source/Mythica/Private/MythicaTypes.h
+++ b/Source/Mythica/Private/MythicaTypes.h
@@ -60,7 +60,8 @@ enum class EMythicaParameterType : uint8
     Float,
     Bool,
     String,
-    Enum
+    Enum,
+    File
 };
 
 USTRUCT()
@@ -150,6 +151,30 @@ struct FMythicaParameterEnum
     TArray<FMythicaParameterEnumValue> Values;
 };
 
+USTRUCT()
+struct FMythicaParameterFile
+{
+    GENERATED_BODY()
+
+    UPROPERTY(VisibleAnywhere, Category = "Parameter")
+    EMythicaInputType Type = EMythicaInputType::Mesh;
+
+    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type != EMythicaInputType::Mesh", EditConditionHides))
+    EMythicaExportTransformType TransformType = EMythicaExportTransformType::Relative;
+
+    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Mesh", EditConditionHides))
+    UStaticMesh* Mesh = nullptr;
+
+    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::World", EditConditionHides))
+    TArray<AActor*> Actors;
+
+    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Spline", EditConditionHides))
+    AActor* SplineActor = nullptr;
+
+    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Volume", EditConditionHides))
+    AMythicaInputSelectionVolume* VolumeActor = nullptr;
+};
+
 USTRUCT(BlueprintType)
 struct FMythicaParameter
 {
@@ -178,6 +203,9 @@ struct FMythicaParameter
 
     UPROPERTY(VisibleAnywhere, Category = "Parameter")
     FMythicaParameterEnum ValueEnum;
+ 
+    UPROPERTY(VisibleAnywhere, Category = "Parameter")
+    FMythicaParameterFile ValueFile;
 };
 
 USTRUCT(BlueprintType)

--- a/Source/Mythica/Private/MythicaTypes.h
+++ b/Source/Mythica/Private/MythicaTypes.h
@@ -156,22 +156,22 @@ struct FMythicaParameterFile
 {
     GENERATED_BODY()
 
-    UPROPERTY(VisibleAnywhere, Category = "Parameter")
+    UPROPERTY(EditAnywhere, Category = "Parameter")
     EMythicaInputType Type = EMythicaInputType::Mesh;
 
-    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type != EMythicaInputType::Mesh", EditConditionHides))
+    UPROPERTY(EditAnywhere, Category = "Parameter", meta = (EditCondition = "Type != EMythicaInputType::Mesh", EditConditionHides))
     EMythicaExportTransformType TransformType = EMythicaExportTransformType::Relative;
 
-    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Mesh", EditConditionHides))
+    UPROPERTY(EditAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Mesh", EditConditionHides))
     UStaticMesh* Mesh = nullptr;
 
-    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::World", EditConditionHides))
+    UPROPERTY(EditAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::World", EditConditionHides))
     TArray<AActor*> Actors;
 
-    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Spline", EditConditionHides))
+    UPROPERTY(EditAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Spline", EditConditionHides))
     AActor* SplineActor = nullptr;
 
-    UPROPERTY(VisibleAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Volume", EditConditionHides))
+    UPROPERTY(EditAnywhere, Category = "Parameter", meta = (EditCondition = "Type == EMythicaInputType::Volume", EditConditionHides))
     AMythicaInputSelectionVolume* VolumeActor = nullptr;
 };
 
@@ -204,7 +204,7 @@ struct FMythicaParameter
     UPROPERTY(VisibleAnywhere, Category = "Parameter")
     FMythicaParameterEnum ValueEnum;
  
-    UPROPERTY(VisibleAnywhere, Category = "Parameter")
+    UPROPERTY(EditAnywhere, Category = "Parameter")
     FMythicaParameterFile ValueFile;
 };
 
@@ -213,7 +213,7 @@ struct FMythicaParameters
 {
     GENERATED_BODY()
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Parameter")
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Parameter")
     TArray<FMythicaParameter> Parameters;
 };
 


### PR DESCRIPTION
Refactored how input geometry is represented to better match the latest version of the API. Rather than it being tracked as an independent concept, it is now represented by a "File" parameter type.

This change also cleans up the UI for specifying input geometry to be a lot simpler. They will now each display as entries in the parameter list consistent with all the other parameters.