### PR TITLE
Fix bugs with Mythica component in actor blueprints

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -29,9 +29,9 @@ class UMythicaComponent : public USceneComponent
 public:
     UMythicaComponent();
 
-    virtual void PostLoad() override;
-    virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
     virtual void OnRegister() override;
+    virtual void OnUnregister() override;
+    virtual void OnComponentDestroyed(bool bDestroyingHierarchy) override;
 
     bool CanRegenerateMesh() const;
     void RegenerateMesh();
@@ -48,6 +48,7 @@ private:
     void OnJobDefIdChanged();
 
     void BindWorldInputListeners();
+    void UnbindWorldInputListeners();
     void OnWorldInputTransformUpdated(USceneComponent* InComponent, EUpdateTransformFlags InFlags, ETeleportType InType);
     void OnTransformUpdated(USceneComponent* InComponent, EUpdateTransformFlags InFlags, ETeleportType InType);
 
@@ -56,6 +57,7 @@ private:
 
     void UpdateMesh();
     void UpdatePlaceholderMesh();
+    void DestroyPlaceholderMesh();
 
 public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))


### PR DESCRIPTION
Fixed asserts due to PostEditChangeProperty modifying destroyed component:
- When modifying a component spawned from an actor blueprint, Super::PostEditChangeProperty will cause the component to get re-instantiated. The "this" context after that function will be the old destroyed copy of the component. Fixed by moving this call to the end of the function.

Fixed delegates sometimes now being registered correctly.
- When re-instantiating a component from a blueprint, it will call PostLoad on the newly create component before re-applying the instance data on top of it. This was causing BindWorldInputListeners to fail to re-bind the delegate correctly for the newely re-instantiated component. Fixed by moving setup in "PostLoad" to be done during "OnRegister" which occurs later in the initialization process after all the instance data is re-applied to the new object. One downside of this is "OnUnregister" and "OnRegister" may be called multiple times during complicated initialization processes, but the cost of this logic is low. In the future may want to prevent the placeholder mesh from being re-created redundantly at least.

There is one main remaining issue where the RequestId is not persisted correctly when the component is re-instantiated. This will be addressed in another PR.