### PR TITLE
Fix job leaking during base object re-instantiation

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -70,12 +70,22 @@ public:
     FMythicaParameters Parameters;
 
 private:
+    UPROPERTY(VisibleAnywhere, DuplicateTransient, meta = (EditCondition = "false", EditConditionHides))
     int RequestId = -1;
+
+    UPROPERTY(VisibleAnywhere, DuplicateTransient, meta = (EditCondition = "false", EditConditionHides))
     EMythicaJobState State = EMythicaJobState::Invalid;
+
+    UPROPERTY(VisibleAnywhere, DuplicateTransient, meta = (EditCondition = "false", EditConditionHides))
     FText Message;
+
+    UPROPERTY(VisibleAnywhere, DuplicateTransient, meta = (EditCondition = "false", EditConditionHides))
     double StateBeginTime = 0.0f;
 
+    UPROPERTY(VisibleAnywhere, DuplicateTransient, meta = (EditCondition = "false", EditConditionHides))
     bool QueueRegenerate = false;
+
+    UPROPERTY(Transient)
     FTimerHandle DelayRegenerateHandle;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))


### PR DESCRIPTION
When modifying an input, the PostEditChangeProperty would request a job and populate RequestId. However, the call to Super::PostEditChangeProperty would re-instantiate the component if it came from an actor blueprint. This would cause the RequestId to be cleared and the job would leak.

Fixed by persisting the job related variables in the component across re-instantiation. Move the OnJobStateChanged bind to OnRegister so it will get correctly bound for the re-instantiated instance of the component.

The one remaining issue is that DelayRegenerateHandle is cleared during re-instantiation. However the current use case of this is very minor and I don't think will cause any issues. This only used when moving a slider interactively, and currently that code path doesn't trigger base object re-instantation so should not hit the issue described above.

This PR continues to use the "(EditCondition = "false"" hack to ensure the data is persisted across re-instantiation but doesn't display in the UI. I am still unsure if this is the cleaned setup for doing this.