### PR TITLE
Allow component to execute job with cached data when JobDef not in cache

### DIFF
--- a/Source/Mythica/Private/MythicaComponent.cpp
+++ b/Source/Mythica/Private/MythicaComponent.cpp
@@ -1,6 +1,7 @@
 #include "MythicaComponent.h"
 
 #include "AssetRegistry/AssetRegistryModule.h"
+#include "ObjectTools.h"
 
 #define IMPORT_NAME_LENGTH 10
 
@@ -90,7 +91,7 @@ void UMythicaComponent::RegenerateMesh()
     }
 
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
-    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Parameters, GetImportName(), K2_GetComponentLocation());
+    RequestId = MythicaEditorSubsystem->ExecuteJob(JobDefId.JobDefId, Parameters, GetImportPath(), K2_GetComponentLocation());
 
     if (RequestId > 0 && IsRegistered())
     {
@@ -98,9 +99,12 @@ void UMythicaComponent::RegenerateMesh()
     }
 }
 
-FString UMythicaComponent::GetImportName()
+FString UMythicaComponent::GetImportPath()
 {
-    return ComponentGUID.ToString().Left(IMPORT_NAME_LENGTH);
+    FString ImportFolderClean = ObjectTools::SanitizeObjectName(ToolName);
+    FString ImportNameClean = ObjectTools::SanitizeObjectName(ComponentGUID.ToString().Left(IMPORT_NAME_LENGTH));
+
+    return FPaths::Combine(ImportFolderClean, ImportNameClean);
 }
 
 bool UMythicaComponent::IsJobProcessing() const
@@ -194,6 +198,7 @@ void UMythicaComponent::OnJobDefIdChanged()
     UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
 
     FMythicaJobDefinition Definition = MythicaEditorSubsystem->GetJobDefinitionById(JobDefId.JobDefId);
+    ToolName = Definition.Name;
     Parameters = Definition.Parameters;
 
     State = EMythicaJobState::Invalid;

--- a/Source/Mythica/Private/MythicaComponent.h
+++ b/Source/Mythica/Private/MythicaComponent.h
@@ -35,7 +35,7 @@ public:
 
     bool CanRegenerateMesh() const;
     void RegenerateMesh();
-    FString GetImportName();
+    FString GetImportPath();
 
     EMythicaJobState GetJobState() const { return State; }
     FText GetJobMessage() const { return Message; }
@@ -62,6 +62,9 @@ private:
 public:
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     FMythicaJobDefinitionId JobDefId;
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
+    FString ToolName;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
     FMythicaComponentSettings Settings;

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -921,19 +921,12 @@ void UMythicaEditorSubsystem::OnUploadInputFilesResponse(FHttpRequestPtr Request
 int UMythicaEditorSubsystem::ExecuteJob(
     const FString& JobDefId, 
     const FMythicaParameters& Params, 
-    const FString& ImportName, 
+    const FString& ImportPath,
     const FVector& Origin
 ) {
     if (SessionState != EMythicaSessionState::SessionCreated)
     {
         UE_LOG(LogMythica, Error, TEXT("Unable to create job due to session not created"));
-        return -1;
-    }
-
-    FMythicaJobDefinition Definition = GetJobDefinitionById(JobDefId);
-    if (Definition.JobDefId != JobDefId)
-    {
-        UE_LOG(LogMythica, Error, TEXT("Unknown job definition %s"), *JobDefId);
         return -1;
     }
 
@@ -945,10 +938,6 @@ int UMythicaEditorSubsystem::ExecuteJob(
         UE_LOG(LogMythica, Error, TEXT("Failed to prepare job input files"));
         return -1;
     }
-
-    FString ImportFolderClean = ObjectTools::SanitizeObjectName(Definition.Name);
-    FString ImportNameClean = ObjectTools::SanitizeObjectName(ImportName);
-    FString ImportPath = FPaths::Combine(ImportFolderClean, ImportNameClean);
 
     int RequestId = CreateJob(JobDefId, Params, ImportPath);
 

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -227,7 +227,7 @@ public:
     int ExecuteJob(
         const FString& JobDefId, 
         const FMythicaParameters& Params, 
-        const FString& ImportName, 
+        const FString& ImportPath, 
         const FVector& Origin);
 
     // Delegates


### PR DESCRIPTION
The one missing piece was to cache the ToolName. All the other required data was already cached on the component.

This will be part of a series of PRs for refactoring job definition discovery. Allow it to execute with the cached data will help work around any edge cases that may come up in the new discovery logic. 

The current system downloads all job definitions to the client which doesn't scale. It is going to be refactored to be more granular on which ones it downloads, so edge cases with the job definition not being downloaded will likely start to come up.