### PR TITLE
Stub in new tool selection UI

### DIFF
--- a/Source/Mythica/Private/MythicaComponentDetails.h
+++ b/Source/Mythica/Private/MythicaComponentDetails.h
@@ -2,6 +2,15 @@
 
 #include "IDetailCustomization.h"
 
+struct FMythicaToolOptionData
+{
+    FString JobDefId;
+    FString Name;
+    FString Owner;
+    FString AssetName;
+    FString Version;
+};
+
 class FMythicaComponentDetails : public IDetailCustomization
 {
 public:
@@ -11,8 +20,9 @@ public:
 
 private:
     TArray<TSharedPtr<FString>> Options;
-    TArray<FString> JobDefIds;
+    TArray<FMythicaToolOptionData> OptionData;
 
-    void OnSelectionChanged(const FString& NewValue, TWeakObjectPtr<class UMythicaComponent> ComponentWeak);
+    void PopulateToolOptions();
+    void SelectTool(const FString& JobDefId, TWeakObjectPtr<class UMythicaComponent> ComponentWeak);
     FString GetSelectedOption(TWeakObjectPtr<class UMythicaComponent> ComponentWeak) const;
 };

--- a/Source/Mythica/Private/MythicaComponentDetails.h
+++ b/Source/Mythica/Private/MythicaComponentDetails.h
@@ -24,5 +24,5 @@ private:
 
     void PopulateToolOptions();
     void SelectTool(const FString& JobDefId, TWeakObjectPtr<class UMythicaComponent> ComponentWeak);
-    FString GetSelectedOption(TWeakObjectPtr<class UMythicaComponent> ComponentWeak) const;
+    FString GetComboBoxDisplayString(TWeakObjectPtr<class UMythicaComponent> ComponentWeak) const;
 };


### PR DESCRIPTION
New UI:
![image](https://github.com/user-attachments/assets/0047dd9f-86fa-493f-87bd-7cc8af60eca2)

This PR also improves the search to also scan the owner and asset version name when filtering.