### PR TITLE
Support updating to newer revision of the same job_def version

### DIFF
--- a/Source/Mythica/Private/MythicaComponentDetails.cpp
+++ b/Source/Mythica/Private/MythicaComponentDetails.cpp
@@ -291,7 +291,8 @@ void FMythicaComponentDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuil
                                 UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
                                 FMythicaJobDefinition LatestDefinition = MythicaEditorSubsystem->GetJobDefinitionLatest(ComponentWeak->Source);
 
-                                if (ComponentWeak->Source.Version < LatestDefinition.Source.Version)
+                                if (ComponentWeak->Source.Version < LatestDefinition.Source.Version
+                                    || ComponentWeak->Source.Version == LatestDefinition.Source.Version && ComponentWeak->JobDefId.JobDefId != LatestDefinition.JobDefId)
                                 {
                                     return EVisibility::Visible;
                                 }

--- a/Source/Mythica/Private/MythicaEditorSubsystem.cpp
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.cpp
@@ -74,6 +74,11 @@ bool FMythicaAssetVersion::operator<(const FMythicaAssetVersion& Other) const
         || (Major == Other.Major && Minor == Other.Minor && Patch < Other.Patch);
 }
 
+bool FMythicaAssetVersion::operator==(const FMythicaAssetVersion& Other) const
+{
+    return Major == Other.Major && Minor == Other.Minor && Patch == Other.Patch;
+}
+
 bool FMythicaAssetVersion::IsValid() const
 {
     return Major > 0 || Minor > 0 || Patch > 0;

--- a/Source/Mythica/Private/MythicaEditorSubsystem.h
+++ b/Source/Mythica/Private/MythicaEditorSubsystem.h
@@ -64,6 +64,7 @@ struct FMythicaAssetVersion
     int32 Patch = 0;
 
     bool operator<(const FMythicaAssetVersion& Other) const;
+    bool operator==(const FMythicaAssetVersion& Other) const;
     bool IsValid() const;
     FString ToString() const;
 };


### PR DESCRIPTION
An asset version can be edited after it is published. We currently don't expose a clean revision number to detect this.

Detecting by checking if the service is providing a different job_def for the same asset version. The one provided by the service should always be the latest revision,