### PR TITLE
Remove placholder icon from tool selector

### DIFF
--- a/Source/Mythica/Private/MythicaComponentDetails.cpp
+++ b/Source/Mythica/Private/MythicaComponentDetails.cpp
@@ -163,11 +163,12 @@ void FMythicaComponentDetails::CustomizeDetails(IDetailLayoutBuilder& DetailBuil
                                             return SNew(SHorizontalBox)
                                                 + SHorizontalBox::Slot()
                                                 .AutoWidth()
-                                                .Padding(FMargin(5.0f))
+                                                .Padding(FMargin(0.0f, 0.0f, 3.0f, 0.0f))
                                                 [
                                                     SNew(SImage)
-                                                        .Image(FCoreStyle::Get().GetBrush("DefaultIcon"))
-                                                        .DesiredSizeOverride(FVector2D(32.0f, 32.0f))
+                                                        .Image(FAppStyle::GetBrush("GenericWhiteBox"))
+                                                        .ColorAndOpacity(FLinearColor(0.0f, 0.25f, 0.0f))
+                                                        .DesiredSizeOverride(FVector2D(3.0f, 40.0f))
                                                 ]
                                                 + SHorizontalBox::Slot()
                                                 .FillWidth(1.0f)


### PR DESCRIPTION
Will consider adding it back in once we have good icons for our tools. Replaced it with a simpler visual divider.

![image](https://github.com/user-attachments/assets/3dd23907-957c-4f75-a1ab-4fbecf8b80b6)
