### PR TITLE
Fix component getting in bad state when saving during job execution

### DIFF
--- a/Source/MythicaEditor/Private/MythicaComponent.cpp
+++ b/Source/MythicaEditor/Private/MythicaComponent.cpp
@@ -41,7 +41,16 @@ void UMythicaComponent::OnRegister()
     if (RequestId > 0)
     {
         UMythicaEditorSubsystem* MythicaEditorSubsystem = GEditor->GetEditorSubsystem<UMythicaEditorSubsystem>();
-        MythicaEditorSubsystem->OnJobStateChange.AddDynamic(this, &UMythicaComponent::OnJobStateChanged);
+
+        State = MythicaEditorSubsystem->GetRequestState(RequestId);
+        if (IsJobProcessing())
+        {
+            MythicaEditorSubsystem->OnJobStateChange.AddDynamic(this, &UMythicaComponent::OnJobStateChanged);
+        }
+        else
+        {
+            RequestId = -1;
+        }
     }
 }
 

--- a/Source/MythicaEditor/Private/MythicaEditorSubsystem.cpp
+++ b/Source/MythicaEditor/Private/MythicaEditorSubsystem.cpp
@@ -248,6 +248,12 @@ FMythicaStats UMythicaEditorSubsystem::GetStats()
     return Stats;
 }
 
+EMythicaJobState UMythicaEditorSubsystem::GetRequestState(int RequestId)
+{
+    FMythicaJob* RequestData = Jobs.Find(RequestId);
+    return RequestData ? RequestData->State : EMythicaJobState::Invalid;
+}
+
 FString UMythicaEditorSubsystem::GetImportDirectory(int RequestId)
 {
     FMythicaJob* RequestData = Jobs.Find(RequestId);

--- a/Source/MythicaEditor/Private/MythicaEditorSubsystem.h
+++ b/Source/MythicaEditor/Private/MythicaEditorSubsystem.h
@@ -248,6 +248,9 @@ public:
     FMythicaStats GetStats();
 
     UFUNCTION(BlueprintPure, Category = "Mythica")
+    EMythicaJobState GetRequestState(int RequestId);
+
+    UFUNCTION(BlueprintPure, Category = "Mythica")
     FString GetImportDirectory(int RequestId);
 
     // Requests


### PR DESCRIPTION
This is related to this change: https://github.com/MythicaAI/MythicaUnrealPlugin/pull/150

This would occur when the State is saved out when it has the value "Processing". When you reload the editor it will recreate the component in a state where it is still waiting for a result still. However the job is no longer being tracked by the editor so it will never get any more messages about it and will be stuck in a non-functional state.

The simplest solution here is to just not persist RequestId/State between editor runs. However making this serialize was needed to handle the case of the component being re-instantiated due to the base actor class being modified. I have been unable to find the settings to make these variables persist through that re-instantiation but not persist across level save/load.

To mitigate this issue, updated the logic to reconcile the component state with the subsystem. This logic is more technically correct as the subsystem is the source of truth and updates the value on the component with a delegate call. So this reconcile will handle the case where the component may have missed any events while unregistered.

This isn't actually fully correct though, since RequestIds are not unique between editor runs. So this fix will usually work, but there is still a hole where it may grab the state of another job that may be in the middle of running that happens to have the same RequestId. This is unlikely so this change should work for now, but we should likely change the component to store the JobId to be precise.

There are also a few other variables on this structure like QueueRegenerate that should maybe be handled a bit differently too in this case. Will think about those in separate PR.

Not worried yet about trying to make this logic perfect, as we will likely soon refactor how job result state is stored and may also figure out better how to distinguish that root issue mentioned above how of to just not persist this state at all between editor runs.