### PR TITLE
Refactor job results to stream item pattern

### DIFF
--- a/Source/MythicaEditor/Private/MythicaEditorSubsystem.h
+++ b/Source/MythicaEditor/Private/MythicaEditorSubsystem.h
@@ -326,6 +326,7 @@ private:
 
     void OnExecuteJobResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId);
     void OnJobResultsResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId);
+    void OnStreamItem(TSharedPtr<FJsonObject> StreamItem);
     void OnMeshDownloadInfoResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId);
     void OnMeshDownloadResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful, int RequestId);
 


### PR DESCRIPTION
Restructuring the logic to prepare for the new profile based websocket stream pattern. Keeping the old polling job results path working for now in the meantime.