### PR TITLE
Hide record_profile option from Unreal UI

### DIFF
--- a/Source/MythicaEditor/Private/MythicaTypes.cpp
+++ b/Source/MythicaEditor/Private/MythicaTypes.cpp
@@ -131,7 +131,8 @@ void FMythicaParameterFile::Copy(const FMythicaParameterFile& Source)
 
 const TCHAR* SystemParameters[] =
 {
-    TEXT("format")
+    TEXT("format"),
+    TEXT("record_profile")
 };
 
 bool Mythica::IsSystemParameter(const FString& Name)


### PR DESCRIPTION
Currently we are just using this for our own debugging. Going to hide the option from the Unreal UX for now until we decide how to properly expose this to users.