### PR TITLE
Fix Source not persisting across object re-instantiation

### DIFF
--- a/Source/MythicaEditor/Private/MythicaEditorSubsystem.cpp
+++ b/Source/MythicaEditor/Private/MythicaEditorSubsystem.cpp
@@ -225,7 +225,7 @@ FMythicaJobDefinition UMythicaEditorSubsystem::GetJobDefinitionLatest(const FMyt
     {
         if (EntryPointReference.Compare(Definition.Source) && LatestDefinition.Source.Version < Definition.Source.Version)
         {
-            return LatestDefinition = Definition;
+            LatestDefinition = Definition;
         }
     }
 

--- a/Source/MythicaEditor/Private/MythicaEditorSubsystem.h
+++ b/Source/MythicaEditor/Private/MythicaEditorSubsystem.h
@@ -56,13 +56,13 @@ struct FMythicaAssetVersion
 {
     GENERATED_BODY()
     
-    UPROPERTY(BlueprintReadOnly, Category = "Version")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Version")
     int32 Major = 0;
     
-    UPROPERTY(BlueprintReadOnly, Category = "Version")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Version")
     int32 Minor = 0;
     
-    UPROPERTY(BlueprintReadOnly, Category = "Version")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Version")
     int32 Patch = 0;
 
     bool operator<(const FMythicaAssetVersion& Other) const;
@@ -76,19 +76,19 @@ struct FMythicaAssetVersionEntryPointReference
 {
     GENERATED_BODY()
 
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Data")
     FString AssetId;
 
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Data")
     FMythicaAssetVersion Version;
 
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Data")
     FString FileId;
 
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Data")
     FString FileName;
 
-    UPROPERTY(BlueprintReadOnly, Category = "Data")
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Data")
     FString EntryPoint;
 
     bool IsValid() const;


### PR DESCRIPTION
This PR continues to use the workaround to fields not persisting across base object re-instantiation: #150 

Also fixes a typo in GetJobDefinitionLatest