### PR TITLE
Scene to actor

### DIFF
--- a/Source/MythicaEditor/Private/MythicaComponent.cpp
+++ b/Source/MythicaEditor/Private/MythicaComponent.cpp
@@ -365,6 +365,7 @@ void UMythicaComponent::UpdateMesh()
     AActor* OwnerActor = GetOwner();
     ensure(OwnerActor);
 
+    // Used to trigger a save object in the level instance so that we can save the new instance components. I think its supposed to wrap the changes, but works without this call.
     OwnerActor->Modify();
 
     // Clear existing meshes but save cache for re-use
@@ -396,9 +397,6 @@ void UMythicaComponent::UpdateMesh()
 
     TArray<FAssetData> Assets;
     AssetRegistryModule.Get().GetAssetsByPath(*ImportDirectory, Assets, true, false);
-
-    // Used to trigger a save object in the level instance so that we can save the new instance components.
-    // UKismetSystemLibrary::TransactObject(OwnerActor);
 
     for (FAssetData Asset : Assets)
     {
@@ -445,9 +443,8 @@ void UMythicaComponent::UpdateMesh()
         MeshComponent->DestroyComponent();
     }
 
+    // Used to trigger a save object in the level instance so that we can save the new instance components.
     OwnerActor->Modify();
-
-    //UKismetSystemLibrary::EndTransaction();
 
     UpdatePlaceholderMesh();
 }
@@ -476,6 +473,7 @@ void UMythicaComponent::UpdatePlaceholderMesh()
     }
     else if (!MeshComponentNames.IsEmpty() && IsValid(PlaceholderMeshComponent))
     {
+        Owner->RemoveOwnedComponent(PlaceholderMeshComponent);
         PlaceholderMeshComponent->DestroyComponent();
         PlaceholderMeshComponent = nullptr;
     }

--- a/Source/MythicaEditor/Private/MythicaComponent.cpp
+++ b/Source/MythicaEditor/Private/MythicaComponent.cpp
@@ -419,14 +419,12 @@ void UMythicaComponent::UpdateMesh()
         // Otherwise spawn a new one
         if (!MeshComponent)
         {
-            MeshComponent = CastChecked<UStaticMeshComponent>(OwnerActor->AddComponentByClass(UStaticMeshComponent::StaticClass(), true, FTransform::Identity, false));
-            // MeshComponent = NewObject<UStaticMeshComponent>(OwnerActor);
+            MeshComponent = NewObject<UStaticMeshComponent>(OwnerActor);
             MeshComponent->SetStaticMesh(Cast<UStaticMesh>(Asset.GetAsset()));
-            //MeshComponent->SetWorldLocation(GetOwner()->GetActorLocation());
-            MeshComponent->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
+            MeshComponent->SetupAttachment(OwnerActor->GetRootComponent());
 
-            //OwnerActor->AddInstanceComponent(MeshComponent);
-            //MeshComponent->RegisterComponent();
+            OwnerActor->AddInstanceComponent(MeshComponent);
+            MeshComponent->RegisterComponent();
         }
 
         MythicaEditorSubsystem->SetJobsCachedAssetData(RequestId, Asset);
@@ -445,37 +443,36 @@ void UMythicaComponent::UpdateMesh()
 
 void UMythicaComponent::UpdatePlaceholderMesh()
 {
-    AActor* Owner = GetOwner();
-    ensure(Owner);
+    //AActor* Owner = GetOwner();
+    //ensure(Owner);
 
-    if (MeshComponentNames.IsEmpty() && !PlaceholderMeshComponent)
-    {
-        UStaticMesh* Mesh = Cast<UStaticMesh>(StaticLoadObject(UStaticMesh::StaticClass(), NULL, PLACEHOLDER_MESH_ASSET));
+    //if (MeshComponentNames.IsEmpty() && !PlaceholderMeshComponent)
+    //{
+    //    UStaticMesh* Mesh = Cast<UStaticMesh>(StaticLoadObject(UStaticMesh::StaticClass(), NULL, PLACEHOLDER_MESH_ASSET));
 
-        PlaceholderMeshComponent = NewObject<UStaticMeshComponent>(
-            this, UStaticMeshComponent::StaticClass(), NAME_None, RF_Transactional);
+    //    PlaceholderMeshComponent = NewObject<UStaticMeshComponent>(
+    //        this, UStaticMeshComponent::StaticClass(), NAME_None, RF_Transactional);
 
-        // Owner->AddComponentByClass();
-
-        PlaceholderMeshComponent->SetStaticMesh(Mesh);
-        PlaceholderMeshComponent->SetHiddenInGame(true);
-        PlaceholderMeshComponent->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
-        PlaceholderMeshComponent->RegisterComponent();
-    }
-    else if (!MeshComponentNames.IsEmpty() && PlaceholderMeshComponent)
-    {
-        PlaceholderMeshComponent->DetachFromComponent(FDetachmentTransformRules::KeepRelativeTransform);
-        PlaceholderMeshComponent->UnregisterComponent();
-        PlaceholderMeshComponent->DestroyComponent();
-        PlaceholderMeshComponent = nullptr;
-    }
+    //    PlaceholderMeshComponent->SetStaticMesh(Mesh);
+    //    PlaceholderMeshComponent->SetHiddenInGame(true);
+    //    PlaceholderMeshComponent->SetupAttachment(GetOwner()->GetRootComponent());
+    //    //PlaceholderMeshComponent->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
+    //    PlaceholderMeshComponent->RegisterComponent();
+    //}
+    //else if (!MeshComponentNames.IsEmpty() && PlaceholderMeshComponent)
+    //{
+    //    //PlaceholderMeshComponent->DetachFromComponent(FDetachmentTransformRules::KeepRelativeTransform);
+    //    PlaceholderMeshComponent->UnregisterComponent();
+    //    PlaceholderMeshComponent->DestroyComponent();
+    //    PlaceholderMeshComponent = nullptr;
+    //}
 }
 
 void UMythicaComponent::DestroyPlaceholderMesh()
 {
-    if (PlaceholderMeshComponent)
-    {
-        PlaceholderMeshComponent->DestroyComponent();
-        PlaceholderMeshComponent = nullptr;
-    }
+    //if (PlaceholderMeshComponent)
+    //{
+    //    PlaceholderMeshComponent->DestroyComponent();
+    //    PlaceholderMeshComponent = nullptr;
+    //}
 }

--- a/Source/MythicaEditor/Private/MythicaComponent.cpp
+++ b/Source/MythicaEditor/Private/MythicaComponent.cpp
@@ -397,7 +397,6 @@ void UMythicaComponent::UpdateMesh()
 
     TArray<FAssetData> Assets;
     AssetRegistryModule.Get().GetAssetsByPath(*ImportDirectory, Assets, true, false);
-
     for (FAssetData Asset : Assets)
     {
         if (!Asset.IsInstanceOf(UStaticMesh::StaticClass()))
@@ -423,7 +422,8 @@ void UMythicaComponent::UpdateMesh()
         // Otherwise spawn a new one
         if (!MeshComponent)
         {
-            MeshComponent = NewObject<UStaticMeshComponent>(OwnerActor, Asset.AssetName, RF_Transactional);
+            FString ComponentName = FString::Printf(TEXT("GEN_%s"), *GetName());
+            MeshComponent = NewObject<UStaticMeshComponent>(OwnerActor, *ComponentName, RF_Transactional);
 
             MeshComponent->SetStaticMesh(Cast<UStaticMesh>(Asset.GetAsset()));
             MeshComponent->SetupAttachment(OwnerActor->GetRootComponent());

--- a/Source/MythicaEditor/Private/MythicaComponent.cpp
+++ b/Source/MythicaEditor/Private/MythicaComponent.cpp
@@ -362,6 +362,7 @@ void UMythicaComponent::OnJobStateChanged(int InRequestId, EMythicaJobState InSt
 void UMythicaComponent::UpdateMesh()
 {
     AActor* OwnerActor = GetOwner();
+    ensure(OwnerActor);
 
     // Clear existing meshes but save cache for re-use
     TArray<UStaticMeshComponent*> ExistingMeshCache;
@@ -394,6 +395,9 @@ void UMythicaComponent::UpdateMesh()
     TArray<FAssetData> Assets;
     AssetRegistryModule.Get().GetAssetsByPath(*ImportDirectory, Assets, true, false);
 
+    // Used to trigger a save object in the level instance so that we can save the new instance components.
+    UKismetSystemLibrary::TransactObject(OwnerActor);
+
     for (FAssetData Asset : Assets)
     {
         if (!Asset.IsInstanceOf(UStaticMesh::StaticClass()))
@@ -420,6 +424,7 @@ void UMythicaComponent::UpdateMesh()
         if (!MeshComponent)
         {
             MeshComponent = NewObject<UStaticMeshComponent>(OwnerActor);
+
             MeshComponent->SetStaticMesh(Cast<UStaticMesh>(Asset.GetAsset()));
             MeshComponent->SetupAttachment(OwnerActor->GetRootComponent());
 
@@ -437,6 +442,8 @@ void UMythicaComponent::UpdateMesh()
     {
         MeshComponent->DestroyComponent();
     }
+
+    UKismetSystemLibrary::EndTransaction();
 
     UpdatePlaceholderMesh();
 }

--- a/Source/MythicaEditor/Private/MythicaComponent.h
+++ b/Source/MythicaEditor/Private/MythicaComponent.h
@@ -116,8 +116,8 @@ private:
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     TMap<EMythicaJobState, double> StateDurations = TMap<EMythicaJobState, double>();
 
-    UPROPERTY(Transient)
-    TObjectPtr<UStaticMeshComponent> PlaceholderMeshComponent = nullptr;
+    //UPROPERTY(Transient)
+    //TObjectPtr<UStaticMeshComponent> PlaceholderMeshComponent = nullptr;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     TArray<FName> MeshComponentNames = TArray<FName>();

--- a/Source/MythicaEditor/Private/MythicaComponent.h
+++ b/Source/MythicaEditor/Private/MythicaComponent.h
@@ -6,28 +6,44 @@
 #include "MythicaTypes.h"
 #include "MythicaComponent.generated.h"
 
+/**
+ * FMythicaComponentSettings
+ *
+ * Used to store important settings about how the component functions.
+ */
 USTRUCT(BlueprintType)
 struct FMythicaComponentSettings
 {
+
     GENERATED_BODY()
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
+public:
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
     bool RegenerateOnParameterChange = false;
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
     bool RegenerateOnInputChange = false;
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
     bool RegenerateOnTransformChange = false;
 };
 
-UCLASS( ClassGroup=(Mythica), meta=(BlueprintSpawnableComponent), hidecategories=(Activation, Cooking, AssetUserData))
+/**
+ * UMythicaComponent
+ *
+ * A component that interfaces with Mythica's API to generate mesh assets and add them to an actor.
+ * This is an Editor-Only component which will get stripped in production builds so do not rely on it for
+ * runtime applications.
+ */
+UCLASS( ClassGroup=(Mythica), meta=(BlueprintSpawnableComponent), hidecategories=(Activation, Cooking, AssetUserData, Navigation))
 class UMythicaComponent : public UActorComponent
 {
     GENERATED_BODY()
 
 public:
-    UMythicaComponent();
+
+    UMythicaComponent(const FObjectInitializer& ObjectInitializer);
 
     virtual void OnRegister() override;
     virtual void OnUnregister() override;
@@ -76,25 +92,26 @@ private:
 
 public:
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
+    UPROPERTY(BlueprintReadOnly)
     FMythicaJobDefinitionId JobDefId = FMythicaJobDefinitionId();
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
+    UPROPERTY(BlueprintReadOnly)
     FMythicaAssetVersionEntryPointReference Source = FMythicaAssetVersionEntryPointReference();
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
+    UPROPERTY(BlueprintReadOnly)
     FString ToolName = FString();
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
     FMythicaComponentSettings Settings = FMythicaComponentSettings();
 
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters")
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica|Parameters")
     FMythicaParameters Parameters = FMythicaParameters();
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica|Components")
     TSet<TObjectPtr<USceneComponent>> WorldInputComponents = TSet<TObjectPtr<USceneComponent>>();
 
 private:
+
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     int RequestId = -1;
 
@@ -110,16 +127,16 @@ private:
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     bool QueueRegenerate = false;
 
-    UPROPERTY(Transient)
+    UPROPERTY(Transient, DuplicateTransient)
     FTimerHandle DelayRegenerateHandle;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     TMap<EMythicaJobState, double> StateDurations = TMap<EMythicaJobState, double>();
 
-    //UPROPERTY(Transient)
-    //TObjectPtr<UStaticMeshComponent> PlaceholderMeshComponent = nullptr;
+    UPROPERTY(Transient, DuplicateTransient)
+    TObjectPtr<UStaticMeshComponent> PlaceholderMeshComponent = nullptr;
 
-    UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
+    UPROPERTY(VisibleAnywhere, Category = "Mythica|Components", meta = (EditCondition = "false", EditConditionHides))
     TArray<FName> MeshComponentNames = TArray<FName>();
 
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))

--- a/Source/MythicaEditor/Private/MythicaComponent.h
+++ b/Source/MythicaEditor/Private/MythicaComponent.h
@@ -107,9 +107,6 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica|Parameters")
     FMythicaParameters Parameters = FMythicaParameters();
 
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica|Components")
-    TSet<TObjectPtr<USceneComponent>> WorldInputComponents = TSet<TObjectPtr<USceneComponent>>();
-
 private:
 
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
@@ -141,4 +138,7 @@ private:
 
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     FGuid ComponentGuid = FGuid();
+
+    UPROPERTY(Transient, DuplicateTransient)
+    TSet<TObjectPtr<USceneComponent>> WorldInputComponents = TSet<TObjectPtr<USceneComponent>>();
 };

--- a/Source/MythicaEditor/Private/MythicaComponent.h
+++ b/Source/MythicaEditor/Private/MythicaComponent.h
@@ -12,17 +12,17 @@ struct FMythicaComponentSettings
     GENERATED_BODY()
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
-    bool RegenerateOnParameterChange = true;
+    bool RegenerateOnParameterChange = false;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
-    bool RegenerateOnInputChange = true;
+    bool RegenerateOnInputChange = false;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
     bool RegenerateOnTransformChange = false;
 };
 
-UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent), hidecategories=(Rendering, Activation, Cooking, Physics, LOD, Navigation, AssetUserData))
-class UMythicaComponent : public USceneComponent
+UCLASS( ClassGroup=(Mythica), meta=(BlueprintSpawnableComponent), hidecategories=(Activation, Cooking, AssetUserData))
+class UMythicaComponent : public UActorComponent
 {
     GENERATED_BODY()
 
@@ -66,7 +66,6 @@ private:
     void BindWorldInputListeners();
     void UnbindWorldInputListeners();
     void OnWorldInputTransformUpdated(USceneComponent* InComponent, EUpdateTransformFlags InFlags, ETeleportType InType);
-    void OnTransformUpdated(USceneComponent* InComponent, EUpdateTransformFlags InFlags, ETeleportType InType);
 
     UFUNCTION()
     void OnJobStateChanged(int InRequestId, EMythicaJobState InState, FText InMessage);
@@ -76,23 +75,24 @@ private:
     void DestroyPlaceholderMesh();
 
 public:
-    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    FMythicaJobDefinitionId JobDefId;
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    FMythicaAssetVersionEntryPointReference Source;
+    FMythicaJobDefinitionId JobDefId = FMythicaJobDefinitionId();
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    FString ToolName;
+    FMythicaAssetVersionEntryPointReference Source = FMythicaAssetVersionEntryPointReference();
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
+    FString ToolName = FString();
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mythica")
-    FMythicaComponentSettings Settings;
+    FMythicaComponentSettings Settings = FMythicaComponentSettings();
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Parameters")
-    FMythicaParameters Parameters;
+    FMythicaParameters Parameters = FMythicaParameters();
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
-    TSet<USceneComponent*> WorldInputComponents;
+    TSet<TObjectPtr<USceneComponent>> WorldInputComponents = TSet<TObjectPtr<USceneComponent>>();
 
 private:
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
@@ -102,7 +102,7 @@ private:
     EMythicaJobState State = EMythicaJobState::Invalid;
 
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    FText Message;
+    FText Message = FText();
 
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
     double StateBeginTime = 0.0f;
@@ -114,14 +114,14 @@ private:
     FTimerHandle DelayRegenerateHandle;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    TMap<EMythicaJobState, double> StateDurations;
+    TMap<EMythicaJobState, double> StateDurations = TMap<EMythicaJobState, double>();
 
     UPROPERTY(Transient)
-    UStaticMeshComponent* PlaceholderMeshComponent = nullptr;
+    TObjectPtr<UStaticMeshComponent> PlaceholderMeshComponent = nullptr;
 
     UPROPERTY(VisibleAnywhere, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    TArray<FName> MeshComponentNames;
+    TArray<FName> MeshComponentNames = TArray<FName>();
 
     UPROPERTY(VisibleAnywhere, DuplicateTransient, Category = "Mythica", meta = (EditCondition = "false", EditConditionHides))
-    FGuid ComponentGuid;
+    FGuid ComponentGuid = FGuid();
 };

--- a/Source/MythicaEditor/Private/UI/SceneHelperEditorWidget.cpp
+++ b/Source/MythicaEditor/Private/UI/SceneHelperEditorWidget.cpp
@@ -121,7 +121,7 @@ void USceneHelperEditorWidget::OnJobStateChanged(int RequestId, EMythicaJobState
 
     if (State >= EMythicaJobState::Completed)
     {
-        Stats.ActiveJobsCount--;
+        Stats.ActiveJobsCount = FMath::Max(Stats.ActiveJobsCount-1, 0);
         Stats.FinishedJobsCount++;
     }
 }
@@ -173,7 +173,7 @@ void USceneHelperEditorWidget::NativePoll()
         }
 
         // Storing the unique parent actors for stats
-        MythicaActors.Emplace(MythComp->GetAttachParentActor());
+        MythicaActors.Emplace(MythComp->GetOwner());
 
         FString DisplayName = UKismetSystemLibrary::GetDisplayName(MythComp);
         TrackedCompIds.Emplace(DisplayName);


### PR DESCRIPTION
- Converting the Mythica SceneComponent into an ActorComponent.
- Ensuring the UI display cannot exceed 0 for the active jobs count.
- Cleaning up some categories on the MythicaComponent.
- Ensuring Mesh Modification marks the actor's state as dirty to allow the instance actor to be saved.